### PR TITLE
feat: Adding dynamic vpc block to handle private zones

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,6 +22,21 @@ module "zones" {
   }
 }
 
+module "zones" {
+  source = "../../modules/zones"
+
+  zones = {
+    "private-vpc-terraform-aws-modules-example.com" = {
+      comment = "private-vpc-terraform-aws-modules-examples.com"
+      vpc = {
+        vpc_id = "vpc-16f55d6e"
+      }
+      tags = {
+        Name = "private-vpc-terraform-aws-modules-examples.com"
+      }
+    }
+}
+
 module "records" {
   source = "../../modules/records"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,7 +7,7 @@ module "zones" {
 
   zones = {
     "terraform-aws-modules-example.com" = {
-      comment = "terraform-aws-modules-examples.com (production)"
+      comment = "terraform-aws-modules-example.com (production)"
       tags = {
         Name = "terraform-aws-modules-example.com"
       }
@@ -19,24 +19,17 @@ module "zones" {
         Name = "app.terraform-aws-modules-example.com"
       }
     }
-  }
-}
 
-module "zones" {
-  source = "../../modules/zones"
-
-  zones = {
-    "private-vpc-terraform-aws-modules-example.com" = {
-      comment = "private-vpc-terraform-aws-modules-examples.com"
+    "private-vpc.terraform-aws-modules-example.com" = {
+      comment = "private-vpc.terraform-aws-modules-example.com"
       vpc = {
         vpc_id = module.vpc.vpc_id
       }
       tags = {
-        Name = "private-vpc-terraform-aws-modules-examples.com"
+        Name = "private-vpc.terraform-aws-modules-example.com"
       }
     }
-
-  depends_on = [module.vpc]
+  }
 }
 
 module "records" {
@@ -118,15 +111,6 @@ module "cloudfront" {
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = "my-vpc"
+  name = "my-vpc-for-private-route53-zone"
   cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  tags = {
-    Terraform = "true"
-    Environment = "dev"
-  }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,12 +29,14 @@ module "zones" {
     "private-vpc-terraform-aws-modules-example.com" = {
       comment = "private-vpc-terraform-aws-modules-examples.com"
       vpc = {
-        vpc_id = "vpc-16f55d6e"
+        vpc_id = module.vpc.vpc_id
       }
       tags = {
         Name = "private-vpc-terraform-aws-modules-examples.com"
       }
     }
+
+  depends_on = [module.vpc]
 }
 
 module "records" {
@@ -110,5 +112,21 @@ module "cloudfront" {
 
   viewer_certificate = {
     cloudfront_default_certificate = true
+  }
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
   }
 }

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -21,7 +21,7 @@ This module creates Route53 zones.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create | Whether to create Route53 zone | `bool` | `true` | no |
-| zones | Map of Route53 zone parameters | `map(any)` | `{}` | no |
+| zones | Map of Route53 zone parameters | `any` | `{}` | no |
 
 ## Outputs
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -5,5 +5,12 @@ resource "aws_route53_zone" "this" {
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)
 
+  dynamic "vpc" {
+    for_each = lookup(each.value, "vpc")
+    content {
+      vpc_id = vpc.value
+    }
+  }
+
   tags = lookup(each.value, "tags", null)
 }

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -6,7 +6,7 @@ resource "aws_route53_zone" "this" {
   force_destroy = lookup(each.value, "force_destroy", false)
 
   dynamic "vpc" {
-    for_each = lookup(each.value, "vpc")
+    for_each = lookup(each.value, "vpc", {})
     content {
       vpc_id = vpc.value
     }

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,14 +1,16 @@
 resource "aws_route53_zone" "this" {
-  for_each = var.create ? var.zones : {}
+  for_each = var.create ? var.zones : tomap({})
 
   name          = each.key
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)
 
   dynamic "vpc" {
-    for_each = lookup(each.value, "vpc", {})
+    for_each = length(keys(lookup(each.value, "vpc", {}))) == 0 ? [] : [lookup(each.value, "vpc", {})]
+
     content {
-      vpc_id = vpc.value
+      vpc_id     = vpc.value.vpc_id
+      vpc_region = lookup(vpc.value, "vpc_region", null)
     }
   }
 

--- a/modules/zones/variables.tf
+++ b/modules/zones/variables.tf
@@ -6,6 +6,6 @@ variable "create" {
 
 variable "zones" {
   description = "Map of Route53 zone parameters"
-  type        = map(any)
+  type        = any
   default     = {}
 }


### PR DESCRIPTION
## Description
Taken from https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone#private-zone

This PR allows you to add a `vpc_block` to specify which AWS vpc you want to attach this route53 zone to and create a private hosted zone

## Motivation and Context
This PR allows you to create a private hosted zone(s)

## Breaking Changes
No breaking changes, adding new functionality.

## How Has This Been Tested?
- Tested by creating one / many private hosted zones
- Tested previous functionality by created one / many public hosted zones
- Caution: A limitation of Terraform ("all map elements must have the same type") does not allow you to create a mix of private/public zones in a single `zones` variable.
