### PR TITLE
fix: use tomap() instead of type declaration object()

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -65,9 +65,14 @@ module "records" {
     },
   ]
 
-  depends_on = [module.zones] #, module.cloudfront, module.s3_bucket]
+  depends_on = [module.zones]
 }
 
+module "disabled_records" {
+  source = "../../modules/records"
+
+  create = false
+}
 
 #########
 # Extras - should be created in advance

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -12,7 +12,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : object({})
+  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
   #  for_each = local.recordsets
 
   zone_id = data.aws_route53_zone.this[0].zone_id

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -13,7 +13,6 @@ data "aws_route53_zone" "this" {
 
 resource "aws_route53_record" "this" {
   for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
-  #  for_each = local.recordsets
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 
@@ -26,7 +25,7 @@ resource "aws_route53_record" "this" {
     for_each = length(keys(lookup(each.value, "alias", {}))) == 0 ? [] : [true]
 
     content {
-      name                   = each.value.alias.name # module.api_gateway.this_apigatewayv2_domain_name_configuration.0.target_domain_name
+      name                   = each.value.alias.name
       zone_id                = each.value.alias.zone_id
       evaluate_target_health = lookup(each.value.alias, "evaluate_target_health", false)
     }


### PR DESCRIPTION
## Description

Call to `object()` as a function is not available, use `tomap()`

## Motivation and Context

The ternary expression for records creation contains a call to `object()` which is not available as a function.
To get the same grasp on enforcing type I did use `tomap()` instead of a literal only.

```sh
Error: Call to unknown function

  on .terraform/modules/vault_cluster.dns/modules/records/main.tf line 15, in resource "aws_route53_record" "this":
  15:   for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : object({})

There is no function named "object".
```

## Breaking Changes

None

## How Has This Been Tested?

Terraform (0.12) plan and apply on AWS resources with a `create` input variable set to `false`

```hcl
module "dns" {
  source  = "terraform-aws-modules/route53/aws//modules/records"
  version = "~> 1.2.0"
  zone_id = data.aws_route53_zone.private.zone_id
  create  = false

# ...
}
```