### PR TITLE
fix: /added weighted routing policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,19 +63,7 @@ module "records" {
         zone_id = module.cloudfront.this_cloudfront_distribution_hosted_zone_id
       }
     },
-    {
-      name    = "test"
-      type    = "CNAME"
-      ttl     = "5"
-      records = ["develop.abc.cmcloudlab912.info.",]
-
-      weighted_routing_policy = {
-      weight         = 90
-      }
-      set_identifier = "develop"
-    }
-  ]
-
+  
   depends_on = [module.zones]
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,7 +71,6 @@ module "records" {
       weighted_routing_policy = {
         weight = 90
       }
-      set_identifier = "develop"
     }
   ]
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,7 +72,7 @@ module "records" {
         weight = 90
       }
       set_identifier = "develop"
-    },
+    }
   ]
 
   depends_on = [module.zones]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,6 +63,7 @@ module "records" {
         zone_id = module.cloudfront.this_cloudfront_distribution_hosted_zone_id
       }
     },
+  ]
   
   depends_on = [module.zones]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,6 +63,17 @@ module "records" {
         zone_id = module.cloudfront.this_cloudfront_distribution_hosted_zone_id
       }
     },
+    {
+      name    = "test"
+      type    = "CNAME"
+      ttl     = "5"
+      records = ["develop.abc.cmcloudlab912.info.",]
+
+      weighted_routing_policy = {
+      weight         = 90
+      }
+      set_identifier = "develop"
+    }
   ]
 
   depends_on = [module.zones]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,6 +63,17 @@ module "records" {
         zone_id = module.cloudfront.this_cloudfront_distribution_hosted_zone_id
       }
     },
+    {
+      name    = "test"
+      type    = "CNAME"
+      ttl     = "5"
+      records = ["develop.abc.cmcloudlab912.info.", ]
+
+      weighted_routing_policy = {
+        weight = 90
+      }
+      set_identifier = "develop"
+    },
   ]
 
   depends_on = [module.zones]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -64,7 +64,7 @@ module "records" {
       }
     },
   ]
-  
+
   depends_on = [module.zones]
 }
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -30,4 +30,12 @@ resource "aws_route53_record" "this" {
       evaluate_target_health = lookup(each.value.alias, "evaluate_target_health", false)
     }
   }
+  
+  dynamic "weighted_routing_policy" {
+    for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
+
+    content {
+      weight                 = lookup(each.value.weighted_routing_policy,"weight", true)
+    }
+  }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -35,7 +35,7 @@ resource "aws_route53_record" "this" {
     for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
 
     content {
-      weight                 = lookup(each.value.weighted_routing_policy,"weight", null)
+      weight                 = each.value.weighted_routing_policy.weight
     }
   }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -35,7 +35,7 @@ resource "aws_route53_record" "this" {
     for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
 
     content {
-      weight                 = lookup(each.value.weighted_routing_policy,"weight", true)
+      weight                 = lookup(each.value.weighted_routing_policy,"weight", null)
     }
   }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -30,12 +30,12 @@ resource "aws_route53_record" "this" {
       evaluate_target_health = lookup(each.value.alias, "evaluate_target_health", false)
     }
   }
-  
+
   dynamic "weighted_routing_policy" {
     for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
 
     content {
-      weight                 = each.value.weighted_routing_policy.weight
+      weight = each.value.weighted_routing_policy.weight
     }
   }
 }


### PR DESCRIPTION
## Description
Added weighted routing policy as an option to the module

## Motivation and Context
Fix: This change is important for those who are seeking to have weighted routing policy enabled on their r53 records. it will also make the module more inclusive and mature
it fixes the issue raised as per this url https://github.com/terraform-aws-modules/terraform-aws-route53/issues/16

## Breaking Changes
This doesnt break the functionality of the module currently consumed by the consumers. it is only an optional feature added to the module

## How Has This Been Tested?
I have tested this on my account, it created the following record for me.
test.cmcloudlab912.info	CNAME	Weighted	90	No	develop.abc.cmcloudlab912.info.
and when I dont pass weighted_routing_policy and its weight value to the root module, it will not create that for you below example is when I removed that part from my root module
test.cmcloudlab912.info	CNAME	Simple	-	No	develop.abc.cmcloudlab912.info. 5

see how your change affects other areas of the code, etc.
