### PR TITLE
feat: Added support for delegation sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ There are independent submodules:
 
 - [zones](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zones) - to manage Route53 zones
 - [records](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/records) - to manage Route53 records
+- [delegation-sets](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/delegation-sets) - to manage Route53 delegation sets
 
 ## Usage
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -35,6 +35,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | terraform-aws-modules/cloudfront/aws | n/a |
+| <a name="module_delegation_sets"></a> [delegation\_sets](#module\_delegation\_sets) | ../../modules/delegation-sets | n/a |
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
 | <a name="module_records_with_lists"></a> [records\_with\_lists](#module\_records\_with\_lists) | ../../modules/records | n/a |
@@ -59,6 +60,8 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#output\_route53\_delegation\_set\_id) | ID of Route53 delegation set |
+| <a name="output_route53_delegation_set_name_servers"></a> [route53\_delegation\_set\_name\_servers](#output\_route53\_delegation\_set\_name\_servers) | Name servers in the Route53 delegation set |
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
 | <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,12 +7,21 @@ locals {
   #  zone_id = module.zones.route53_zone_zone_id["app.terraform-aws-modules-example.com"]
 }
 
+module "delegation_sets" {
+  source = "../../modules/delegation-sets"
+
+  delegation_sets = {
+    main = {}
+  }
+}
+
 module "zones" {
   source = "../../modules/zones"
 
   zones = {
     "terraform-aws-modules-example.com" = {
-      comment = "terraform-aws-modules-example.com (production)"
+      comment           = "terraform-aws-modules-example.com (production)"
+      delegation_set_id = module.delegation_sets.route53_delegation_set_id.main
       tags = {
         Name = "terraform-aws-modules-example.com"
       }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,3 +1,14 @@
+# delegation sets
+output "route53_delegation_set_id" {
+  description = "ID of Route53 delegation set"
+  value       = module.delegation_sets.route53_delegation_set_id
+}
+
+output "route53_delegation_set_name_servers" {
+  description = "Name servers in the Route53 delegation set"
+  value       = module.delegation_sets.route53_delegation_set_name_servers
+}
+
 # zones
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"

--- a/modules/delegation-sets/README.md
+++ b/modules/delegation-sets/README.md
@@ -1,0 +1,83 @@
+# Route53 Delegation Sets
+
+This module creates Route53 delegation sets.
+
+## Usage
+
+### Create Route53 delegation sets and public zones using a delegation set
+
+```hcl
+module "delegation_sets" {
+  source  = "terraform-aws-modules/route53/aws//modules/delegation-sets"
+  version = "~> 2.0"
+
+  delegation_sets = {
+    "myset" = {
+      reference_name = "myset"
+    }
+  }
+}
+
+module "zones" {
+  source  = "terraform-aws-modules/route53/aws//modules/zones"
+  version = "~> 2.0"
+
+  zones = {
+    "myapp1.com" = {
+      comment           = "myapp1.com"
+      delegation_set_id = module.delegation_sets.route53_delegation_set_id["myset"]
+    }
+
+    "myapp2.com" = {
+      comment           = "myapp2.com"
+      delegation_set_id = module.delegation_sets.route53_delegation_set_id["myset"]
+    }
+  }
+
+  tags = {
+    ManagedBy = "Terraform"
+  }
+
+  depends_on = [module.delegation_sets]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_delegation_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_delegation_set) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 delegation sets | `bool` | `true` | no |
+| <a name="input_delegation_sets"></a> [delegation\_sets](#input\_delegation\_sets) | Map of Route53 delegation set parameters | `any` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#output\_route53\_delegation\_set\_id) | ID of Route53 delegation set |
+| <a name="output_route53_delegation_set_name_servers"></a> [route53\_delegation\_set\_name\_servers](#output\_route53\_delegation\_set\_name\_servers) | Name servers in the Route53 delegation set |
+| <a name="output_route53_delegation_set_reference_name"></a> [route53\_delegation\_set\_reference\_name](#output\_route53\_delegation\_set\_reference\_name) | Reference name used when the Route53 delegation set has been created |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/delegation-sets/main.tf
+++ b/modules/delegation-sets/main.tf
@@ -1,0 +1,5 @@
+resource "aws_route53_delegation_set" "this" {
+  for_each = var.create ? var.delegation_sets : tomap({})
+
+  reference_name = lookup(each.value, "reference_name", null)
+}

--- a/modules/delegation-sets/outputs.tf
+++ b/modules/delegation-sets/outputs.tf
@@ -1,0 +1,14 @@
+output "route53_delegation_set_id" {
+  description = "ID of Route53 delegation set"
+  value       = { for k, v in aws_route53_delegation_set.this : k => v.id }
+}
+
+output "route53_delegation_set_name_servers" {
+  description = "Name servers in the Route53 delegation set"
+  value       = { for k, v in aws_route53_delegation_set.this : k => v.name_servers }
+}
+
+output "route53_delegation_set_reference_name" {
+  description = "Reference name used when the Route53 delegation set has been created"
+  value       = { for k, v in aws_route53_delegation_set.this : k => v.reference_name }
+}

--- a/modules/delegation-sets/variables.tf
+++ b/modules/delegation-sets/variables.tf
@@ -1,0 +1,11 @@
+variable "create" {
+  description = "Whether to create Route53 delegation sets"
+  type        = bool
+  default     = true
+}
+
+variable "delegation_sets" {
+  description = "Map of Route53 delegation set parameters"
+  type        = any
+  default     = {}
+}

--- a/modules/delegation-sets/versions.tf
+++ b/modules/delegation-sets/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = ">= 3.56"
+  }
+}

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -5,6 +5,8 @@ resource "aws_route53_zone" "this" {
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)
 
+  delegation_set_id = lookup(each.value, "delegation_set_id", null)
+
   dynamic "vpc" {
     for_each = try(tolist(lookup(each.value, "vpc", [])), [lookup(each.value, "vpc", {})])
 


### PR DESCRIPTION
## Description
Add delegation_sets module for creating delegation sets. The implementation (logic, variables and outputs) is similar to the implementation of the zones module.

A delegation set id may be specified in the parameters of a public zone to have that zone use the set of name servers from the delegation set.

Update the example to create and use a delegation set.

## Motivation and Context
By supporting the creation and use of delegation sets, multiple public zones can use the same set of name servers. May be useful when doing batch updates of name servers at other registrars.

## Breaking Changes
It shouldn't break anything, new functionality is added.

## How Has This Been Tested?
Tested by deploying the example.