### PR TITLE
feat: add global tags variable to zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ module "zones" {
       comment = "myapp.com"
     }
   }
+
+  tags = {
+    ManagedBy = "Terraform"
+  }
 }
 
 module "records" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,6 +30,10 @@ module "zones" {
       }
     }
   }
+
+  tags = {
+    ManagedBy = "Terraform"
+  }
 }
 
 module "records" {

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -21,8 +21,8 @@ This module creates Route53 zones.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create | Whether to create Route53 zone | `bool` | `true` | no |
+| tags | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
 | zones | Map of Route53 zone parameters | `any` | `{}` | no |
-| tags | Tags added to all zones. Will take precedence over tags from the `zones` variable | `map(any)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -22,6 +22,7 @@ This module creates Route53 zones.
 |------|-------------|------|---------|:--------:|
 | create | Whether to create Route53 zone | `bool` | `true` | no |
 | zones | Map of Route53 zone parameters | `any` | `{}` | no |
+| tags | Tags added to all zones. Will take precedence over tags from the `zones` variable | `map(any)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -14,5 +14,8 @@ resource "aws_route53_zone" "this" {
     }
   }
 
-  tags = lookup(each.value, "tags", null)
+  tags = merge(
+    lookup(each.value, "tags", {}),
+    var.tags
+  )
 }

--- a/modules/zones/variables.tf
+++ b/modules/zones/variables.tf
@@ -9,3 +9,9 @@ variable "zones" {
   type        = any
   default     = {}
 }
+
+variable "tags" {
+  description = "Tags added to all zones. Will take precedence over tags from the 'zones' variable"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Description
Add a global `tags` variable for tags that should be added to all Route53 zones.

## Motivation and Context
Tags like `ManagedBy = "Terraform"` and similar should only be set once as this will make it much easier to manage.

## How Has This Been Tested?
Zones have been created with and without tags.