### PR TITLE
feat: Add support for multiple VPCs when creating private hosted zones

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,9 +22,14 @@ module "zones" {
 
     "private-vpc.terraform-aws-modules-example.com" = {
       comment = "private-vpc.terraform-aws-modules-example.com"
-      vpc = {
-        vpc_id = module.vpc.vpc_id
-      }
+      vpc = [
+        {
+          vpc_id = module.vpc.vpc_id
+        },
+        {
+          vpc_id = module.vpc2.vpc_id
+        },
+      ]
       tags = {
         Name = "private-vpc.terraform-aws-modules-example.com"
       }
@@ -136,4 +141,11 @@ module "vpc" {
 
   name = "my-vpc-for-private-route53-zone"
   cidr = "10.0.0.0/16"
+}
+
+module "vpc2" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "my-second-vpc-for-private-route53-zone"
+  cidr = "10.1.0.0/16"
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,3 +1,20 @@
+# zones
+output "this_route53_zone_zone_id" {
+  description = "Zone ID of Route53 zone"
+  value       = module.zones.this_route53_zone_zone_id
+}
+
+output "this_route53_zone_name_servers" {
+  description = "Name servers of Route53 zone"
+  value       = module.zones.this_route53_zone_name_servers
+}
+
+output "this_route53_zone_name" {
+  description = "Name of Route53 zone"
+  value       = module.zones.this_route53_zone_name
+}
+
+# records
 output "this_route53_record_name" {
   description = "The name of the record"
   value       = module.records.this_route53_record_name

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -6,7 +6,7 @@ resource "aws_route53_zone" "this" {
   force_destroy = lookup(each.value, "force_destroy", false)
 
   dynamic "vpc" {
-    for_each = length(keys(lookup(each.value, "vpc", {}))) == 0 ? [] : [lookup(each.value, "vpc", {})]
+    for_each = lookup(each.value, "vpc", [])
 
     content {
       vpc_id     = vpc.value.vpc_id

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -6,7 +6,7 @@ resource "aws_route53_zone" "this" {
   force_destroy = lookup(each.value, "force_destroy", false)
 
   dynamic "vpc" {
-    for_each = lookup(each.value, "vpc", [])
+    for_each = try(tolist(lookup(each.value, "vpc", [])), [lookup(each.value, "vpc", {})])
 
     content {
       vpc_id     = vpc.value.vpc_id

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -7,3 +7,8 @@ output "this_route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
   value       = { for k, v in aws_route53_zone.this : k => v.name_servers }
 }
+
+output "this_route53_zone_name" {
+  description = "Name of Route53 zone"
+  value       = { for k, v in aws_route53_zone.this : k => v.name }
+}


### PR DESCRIPTION
## Description
Currently the `zones` module only supports a single VPC. The `aws_route53_zone` resource supports multiple VPCs for private zones so I'm adding support for that.

## Motivation and Context
I needed a private hosted zone with multiple VPCs. This module didn't support it, now it does.

## Breaking Changes
Yes, we are changing `vpc` attribute from a `map` to a `list(map)` so if anyone us using a map, they'll need to wrap with `[{..}]`

## How Has This Been Tested?

I just used it to create a private hosted zone for what I needed.

```HCL
locals {}

terraform {
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-route53.git//modules/zones?ref=v1.6.0"
  source = "/Users/hnicholas/.local/tmp/terraform-aws-route53/modules/zones"
}

include {
  path = find_in_parent_folders()
}

dependency "us_gov_east_1_vpc" {
  config_path = "../../../us-gov-east-1/apps/vpc"
}


dependency "us_gov_west_1_vpc" {
  config_path = "../../../us-gov-west-1/apps/vpc"
}

inputs = {
  zones = {
    "govstg.local" = {
      comment = "Private Route53 Hosted Zone"

      vpc = [
        {
          vpc_id     = dependency.us_gov_east_1_vpc.outputs.vpc_id
          vpc_region = "us-gov-east-1"
        },
        {
          vpc_id     = dependency.us_gov_west_1_vpc.outputs.vpc_id
          vpc_region = "us-gov-west-1"
        },
      ]

      tags = {
        Name = "govstg.local"
      }
    }
  }
}
```

```NOFORMAT
hnicholas@hnicholas-a01:~/Repositories/FR/terraform/live/staging/_global/resources/route53$ aws-vault exec govcloud-staging -- terragrunt apply
[INFO] Getting version from tgenv-version-name
[INFO] TGENV_VERSION is 0.27.1
[terragrunt] [/Users/hnicholas/Repositories/FR/terraform/live/staging/_global/resources/route53] 2021/02/09 17:02:35 Running command: terraform --version
[terragrunt] 2021/02/09 17:02:36 Terraform version: 0.14.4

...


Terraform will perform the following actions:

  # aws_route53_zone.this["govstg.local"] will be created
  + resource "aws_route53_zone" "this" {
      + comment       = "Private Route53 Hosted Zone"
      + force_destroy = false
      + id            = (known after apply)
      + name          = "govstg.local"
      + name_servers  = (known after apply)
      + tags          = {
          + "Name" = "govstg.local"
        }
      + zone_id       = (known after apply)

      + vpc {
          + vpc_id     = "vpc-foo"
          + vpc_region = "us-gov-west-1"
        }
      + vpc {
          + vpc_id     = "vpc-bar"
          + vpc_region = "us-gov-east-1"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + this_route53_zone_name_servers = {
      + govstg.local = (known after apply)
    }
  + this_route53_zone_zone_id      = {
      + govstg.local = (known after apply)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
Releasing state lock. This may take a few moments...

Outputs:

...
```