### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@ Terraform module which creates Route53 resources.
 
 There are independent submodules:
 
-* [zones](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zones) - to manage Route53 zones
-* [records](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/records) - to manage Route53 records
+- [zones](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zones) - to manage Route53 zones
+- [records](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/records) - to manage Route53 records
 
 This module currently does not have all arguments supported by the Terraform AWS providers.
-
 
 ## Terraform versions
 
 Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
-
 
 ## Usage
 
@@ -73,37 +71,15 @@ module "records" {
 
 Note that `depends_on` in modules is available since Terraform 0.13.
 
-
 ## Examples
 
-* [Complete Route53 zones and records example](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/examples/complete) which shows how to create Route53 records of various types like S3 bucket and CloudFront distribution.
-
+- [Complete Route53 zones and records example](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/examples/complete) which shows how to create Route53 records of various types like S3 bucket and CloudFront distribution.
 
 ## Conditional creation
 
 Sometimes you need to have a way to create resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create`.
 
-
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.49, < 4.0 |
-
-## Providers
-
-No provider.
-
-## Inputs
-
-No input.
-
-## Outputs
-
-No output.
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -26,6 +26,22 @@ Note that this example may create resources which cost money. Run `terraform des
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| cloudfront | terraform-aws-modules/cloudfront/aws |  |
+| disabled_records | ../../modules/records |  |
+| records | ../../modules/records |  |
+| s3_bucket | terraform-aws-modules/s3-bucket/aws |  |
+| vpc | terraform-aws-modules/vpc/aws |  |
+| vpc2 | terraform-aws-modules/vpc/aws |  |
+| zones | ../../modules/zones |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -36,5 +52,7 @@ No input.
 |------|-------------|
 | this\_route53\_record\_fqdn | FQDN built using the zone domain and name |
 | this\_route53\_record\_name | The name of the record |
-
+| this\_route53\_zone\_name | Name of Route53 zone |
+| this\_route53\_zone\_name\_servers | Name servers of Route53 zone |
+| this\_route53\_zone\_zone\_id | Zone ID of Route53 zone |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -16,6 +16,17 @@ This module creates DNS records in Route53 zone.
 |------|---------|
 | aws | >= 2.49 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/2.49/docs/resources/route53_record) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.49/docs/data-sources/route53_zone) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -32,5 +43,4 @@ This module creates DNS records in Route53 zone.
 |------|-------------|
 | this\_route53\_record\_fqdn | FQDN built using the zone domain and name |
 | this\_route53\_record\_name | The name of the record |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -16,6 +16,16 @@ This module creates Route53 zones.
 |------|---------|
 | aws | >= 2.49 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.49/docs/resources/route53_zone) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -28,7 +38,7 @@ This module creates Route53 zones.
 
 | Name | Description |
 |------|-------------|
+| this\_route53\_zone\_name | Name of Route53 zone |
 | this\_route53\_zone\_name\_servers | Name servers of Route53 zone |
 | this\_route53\_zone\_zone\_id | Zone ID of Route53 zone |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
