### PR TITLE
feat: Allow creation of delegation NS records in parent domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+<a name="v1.9.0"></a>
+## [v1.9.0] - 2021-02-17
+- feat: Allow automatic creation of delegation NS records in parent domain
+
 
 <a name="v2.0.0"></a>
 ## [v2.0.0] - 2021-04-26

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Route53 Terraform module
 
+This module is derived from [the one with same name maintained by Anton Babenko](https://github.com/terraform-aws-modules/terraform-aws-route53).
+
+In this version, the 'zone' and 'record' modules allow to create a single
+zone and a single record. The 'zones' and 'records' modules  are just calling
+the se modules with for_each loops. This provides a much simpler code as
+it avoids having loops and resource indexes everywhere.
+
+Of course, using loops (for_each/count) on modules is possible since terraform
+0.13 only. So, this module cannot work with a terraform version lower than 0.13.
+
+----------------- Original documentation -----------------------
+
 Terraform module which creates Route53 resources.
 
 There are independent submodules:

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-module "zones" {
+module "zone" {
   source = "../../modules/zones"
 
   zones = {
@@ -13,8 +13,19 @@ module "zones" {
       }
     }
 
+  tags = {
+    ManagedBy = "Terraform"
+  }
+}
+
+
+module "subzones" {
+  source = "../../modules/zones"
+
+  zones = {
     "app.terraform-aws-modules-example.com" = {
       comment = "app.terraform-aws-modules-example.com"
+      parent_id = module.zone.this_route53_zone_zone_id
       tags = {
         Name = "app.terraform-aws-modules-example.com"
       }
@@ -22,6 +33,7 @@ module "zones" {
 
     "private-vpc.terraform-aws-modules-example.com" = {
       comment = "private-vpc.terraform-aws-modules-example.com"
+      parent_id = module.zone.this_route53_zone_zone_id
       vpc = [
         {
           vpc_id = module.vpc.vpc_id
@@ -127,7 +139,7 @@ module "records" {
     }
   ]
 
-  depends_on = [module.zones]
+  depends_on = [module.zone]
 }
 
 module "disabled_records" {

--- a/modules/record/README.md
+++ b/modules/record/README.md
@@ -1,0 +1,46 @@
+# Route53 Records
+
+This module creates DNS records in Route53 zone.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
+| <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
+| <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/record/main.tf
+++ b/modules/record/main.tf
@@ -1,0 +1,53 @@
+locals {
+  zone_id = (var.zone_id == null) ? data.aws_route53_zone.this.zone_id : var.zone_id
+  zone_name = (var.zone_name == null) ? data.aws_route53_zone.this.name : var.zone_name
+
+  type = upper(var.type)
+}
+
+#---
+
+data aws_route53_zone this {
+  zone_id      = var.zone_id
+  name         = var.zone_name
+  private_zone = var.private_zone
+}
+
+#---
+
+resource aws_route53_record this {
+  zone_id = local.zone_id
+
+  name            = var.name != "" ? "${var.name}.${local.zone_name}" : local.zone_name
+  type            = local.type
+  ttl             = var.ttl
+  records         = flatten([var.records])
+  set_identifier  = var.set_identifier
+  health_check_id = var.health_check_id
+
+  dynamic "alias" {
+    for_each = (var.alias == null) ? [] : [true]
+
+    content {
+      name                   = var.alias.name
+      zone_id                = try(var.alias.zone_id, local.zone_id)
+      evaluate_target_health = lookup(var.alias, "evaluate_target_health", false)
+    }
+  }
+
+  dynamic "failover_routing_policy" {
+    for_each = (var.failover_routing_policy == null) ? [] : [true]
+
+    content {
+      type = var.failover_routing_policy.type
+    }
+  }
+
+  dynamic "weighted_routing_policy" {
+    for_each = (var.weighted_routing_policy == null) ? [] : [true]
+
+    content {
+      weight = var.weighted_routing_policy.weight
+    }
+  }
+}

--- a/modules/record/outputs.tf
+++ b/modules/record/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "The name of the record"
+  value       = aws_route53_record.this.name
+}
+
+output "fqdn" {
+  description = "FQDN built using the zone domain and name"
+  value       = aws_route53_record.this.fqdn
+}

--- a/modules/record/variables.tf
+++ b/modules/record/variables.tf
@@ -1,0 +1,70 @@
+# At least one of zone_id/zone_name must be set
+
+variable "zone_id" {
+  description = "ID of DNS zone"
+  type        = string
+  default     = null
+}
+
+variable "zone_name" {
+  description = "Name of DNS zone"
+  type        = string
+  default     = null
+}
+
+variable "private_zone" {
+  description = "Whether Route53 zone is private or public"
+  type        = bool
+  default     = false
+}
+
+variable name {
+  description = "Record name (without domain part, can be empty)"
+  type        = string
+}
+
+variable type {
+  description = "Record type"
+  type        = string
+}
+
+variable ttl {
+  description = "Record TTL"
+  type        = number
+  default     = 300
+}
+
+variable records {
+  description = "Record value(s)"
+  type        = any
+}
+
+variable alias {
+  description = "Alias parameters (name, [zone_id], [evaluate_target_health])"
+  type        = any
+  default     = null
+}
+
+variable set_identifier {
+  description = ""
+  type        = string
+  default     = ""
+}
+
+variable health_check_id {
+  description = "The health check the record should be associated with"
+  type        = any
+  default     = null
+}
+
+variable failover_routing_policy {
+  description = "Optional"
+  type        = any
+  default     = null
+}
+
+variable weighted_routing_policy {
+  description = "Optional"
+  type        = any
+  default     = null
+}

--- a/modules/record/versions.tf
+++ b/modules/record/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.49"
+    }
+  }
+}

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -3,49 +3,21 @@ locals {
   recordsets = { for rs in var.records : join(" ", compact(["${rs.name} ${rs.type}", lookup(rs, "set_identifier", "")])) => rs }
 }
 
-data "aws_route53_zone" "this" {
-  count = var.create && (var.zone_id != null || var.zone_name != null) ? 1 : 0
+module record {
+  source = "../record"
+  for_each = local.recordsets
 
-  zone_id      = var.zone_id
-  name         = var.zone_name
-  private_zone = var.private_zone
-}
+  zone_id                 = var.zone_id
+  zone_name               = var.zone_name
+  private_zone            = var.private_zone
 
-resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
-
-  zone_id = data.aws_route53_zone.this[0].zone_id
-
-  name            = each.value.name != "" ? "${each.value.name}.${data.aws_route53_zone.this[0].name}" : data.aws_route53_zone.this[0].name
-  type            = each.value.type
-  ttl             = lookup(each.value, "ttl", null)
-  records         = lookup(each.value, "records", null)
-  set_identifier  = lookup(each.value, "set_identifier", null)
-  health_check_id = lookup(each.value, "health_check_id", null)
-
-  dynamic "alias" {
-    for_each = length(keys(lookup(each.value, "alias", {}))) == 0 ? [] : [true]
-
-    content {
-      name                   = each.value.alias.name
-      zone_id                = try(each.value.alias.zone_id, data.aws_route53_zone.this[0].zone_id)
-      evaluate_target_health = lookup(each.value.alias, "evaluate_target_health", false)
-    }
-  }
-
-  dynamic "failover_routing_policy" {
-    for_each = length(keys(lookup(each.value, "failover_routing_policy", {}))) == 0 ? [] : [true]
-
-    content {
-      type = each.value.failover_routing_policy.type
-    }
-  }
-
-  dynamic "weighted_routing_policy" {
-    for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
-
-    content {
-      weight = each.value.weighted_routing_policy.weight
-    }
-  }
+  name                    = each.value.name
+  type                    = each.value.type
+  ttl                     = lookup(each.value, "ttl", 300)
+  records                 = each.value.records
+  set_identifier          = lookup(each.value, "set_identifier", "")
+  health_check_id         = lookup(each.value, "health_check_id", null)
+  alias                   = lookup(each.value, "alias", null)
+  failover_routing_policy = lookup(each.value, "failover_routing_policy", null)
+  weighted_routing_policy = lookup(each.value, "weighted_routing_policy", null)
 }

--- a/modules/records/outputs.tf
+++ b/modules/records/outputs.tf
@@ -1,9 +1,9 @@
-output "route53_record_name" {
-  description = "The name of the record"
-  value       = { for k, v in aws_route53_record.this : k => v.name }
+output name {
+  description = "The name of the records"
+  value       = { for k, v in module.record : k => v.name }
 }
 
-output "route53_record_fqdn" {
-  description = "FQDN built using the zone domain and name"
-  value       = { for k, v in aws_route53_record.this : k => v.fqdn }
+output fqdn {
+  description = "FQDNs built using the zone domain and name"
+  value       = { for k, v in module.record : k => v.fqdn }
 }

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -1,9 +1,3 @@
-variable "create" {
-  description = "Whether to create DNS records"
-  type        = bool
-  default     = true
-}
-
 variable "zone_id" {
   description = "ID of DNS zone"
   type        = string

--- a/modules/records/versions.tf
+++ b/modules/records/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = ">= 2.49"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.49"
+    }
   }
 }

--- a/modules/zone/README.md
+++ b/modules/zone/README.md
@@ -1,0 +1,66 @@
+# Route53 Zones
+
+This module creates Route53 zones.
+
+It can also automatically create delegation NS records in the parent zone
+of each newly-created zone. This feature is activated by adding a 'parent_id'
+element in the map defining the zone to create.
+
+Note: When this feature is used, subdomains cannot be created with their
+parent domain in the same module call and calls must be split. See the 'examples' subdirectory to see how it can be done.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Map of Route53 zone parameters | `any` | `{}` | no |
+
+### Route53 zone parameters
+
+Key: Zone name ('x.y.z.com')
+
+Value:
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| comment | Comments | string | null | no |
+| force_destroy | Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone | `bool` | `false` | no |
+| vpc | vpc block to add to zone resource. Keys : vpc_id (mandatory), vpc_region (optional) | `map` | `{}` | no |
+| tags | Tags | `map` | `{}` | no |
+| parent_id | Id of zone where NS records for the new zone will be registered, or null if you don't want to create these records | string or null | null | no |
+| ttl | ttl in seconds for the NS records in the parent zone| number | 300 | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
+| <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -1,0 +1,50 @@
+
+resource aws_route53_zone this {
+  name          = var.name
+  comment       = var.comment
+  force_destroy = var.force_destroy
+
+  dynamic "vpc" {
+    for_each = try(tolist(var.vpc), [var.vpc])
+
+    content {
+      vpc_id     = vpc.value.vpc_id
+      vpc_region = lookup(vpc.value, "vpc_region", null)
+    }
+  }
+
+  tags = var.tags
+}
+
+#---
+
+module records {
+  source = "../records"
+
+  zone_id = aws_route53_zone.this.zone_id
+  private_zone = (var.vpc != [])
+  records = var.records
+}
+
+# If parent zone is provided, register delegation NS records in parent zone
+
+locals {
+  parent_is_set = ((var.parent_id != null) || (var.parent_name != null))
+  parent_zone_id = local.parent_is_set ? ((var.parent_id == null) ? data.aws_route53_zone.parent.0.zone_id : var.parent_id) : null
+}
+
+data aws_route53_zone parent {
+  count = (local.parent_is_set && (var.parent_id == null)) ? 1 : 0
+  name = var.parent_name
+  private_zone = var.parent_is_private
+}
+
+resource aws_route53_record ns_records {
+  count = local.parent_is_set ? 1 : 0
+
+  zone_id = local.parent_zone_id
+  name = var.name
+  type = "NS"
+  ttl = var.ns_ttl
+  records = aws_route53_zone.this.name_servers
+}

--- a/modules/zone/outputs.tf
+++ b/modules/zone/outputs.tf
@@ -1,0 +1,14 @@
+output zone_id {
+  description = "Zone ID of Route53 zone"
+  value       = aws_route53_zone.this.zone_id
+}
+
+output name_servers {
+  description = "Name servers of Route53 zone"
+  value       = aws_route53_zone.this.name_servers
+}
+
+output name {
+  description = "Name of Route53 zone"
+  value       = aws_route53_zone.this.name
+}

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -1,0 +1,62 @@
+
+variable name {
+  description = "Zone name"
+  type        = string
+}
+
+variable comment {
+  description = "Comment"
+  type        = string
+  default     = null
+}
+
+variable force_destroy {
+  description = "Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone"
+  type        = bool
+  default     = false
+}
+
+variable vpc  {
+  description = "VPC(s) to associate with a private hosted zone"
+  type        = any
+  default = []
+}
+
+variable records {
+  description = "List of Route53 records"
+  type        = any
+  default = []
+}
+
+variable "tags" {
+  description = "Tags added to zone"
+  type        = map(string)
+  default     = {}
+}
+
+# If neither parent_id not parent_name are set, NS records
+# for this zone won't be created.
+
+variable parent_id {
+  description = "ID of zone where NS records for this zone will be created"
+  type = string
+  default = null
+}
+
+variable parent_name {
+  description = "Name of zone where NS records for this zone will be created. 'auto' means remove substring up to 1st dot from current zone name"
+  type = string
+  default = null
+}
+
+variable parent_is_private {
+  description = "Wheter parent zone is a private zone"
+  type = bool
+  default = false
+}
+
+variable ns_ttl {
+  description = "TTL for NS records"
+  type = number
+  default = 300
+}

--- a/modules/zone/versions.tf
+++ b/modules/zone/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.49"
+    }
+  }
+}

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -2,6 +2,13 @@
 
 This module creates Route53 zones.
 
+It can also automatically create delegation NS records in the parent zone
+of each newly-created zone. This feature is activated by adding a 'parent_id'
+element in the map defining the zone to create.
+
+Note: When this feature is used, subdomains cannot be created with their
+parent domain in the same module call and calls must be split. See the 'examples' subdirectory to see how it can be done.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -33,6 +40,21 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Map of Route53 zone parameters | `any` | `{}` | no |
+
+### Route53 zone parameters
+
+Key: Zone name ('x.y.z.com')
+
+Value:
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| comment | Comments | string | null | no |
+| force_destroy | Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone | `bool` | `false` | no |
+| vpc | vpc block to add to zone resource. Keys : vpc_id (mandatory), vpc_region (optional) | `map` | `{}` | no |
+| tags | Tags | `map` | `{}` | no |
+| parent_id | Id of zone where NS records for the new zone will be registered, or null if you don't want to create these records | string or null | null | no |
+| ttl | ttl in seconds for the NS records in the parent zone| number | 300 | no |
 
 ## Outputs
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,40 +1,22 @@
-resource "aws_route53_zone" "this" {
-  for_each = var.create ? var.zones : tomap({})
+
+module zone {
+  source = "../zone"
+  for_each = var.zones
 
   name          = each.key
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)
 
-  dynamic "vpc" {
-    for_each = try(tolist(lookup(each.value, "vpc", [])), [lookup(each.value, "vpc", {})])
+  vpc = lookup(each.value, "vpc", [])
+  records = lookup(each.value, "records", {})
 
-    content {
-      vpc_id     = vpc.value.vpc_id
-      vpc_region = lookup(vpc.value, "vpc_region", null)
-    }
-  }
+  parent_id = lookup(each.value, "parent_id", null)
+  parent_name = lookup(each.value, "parent_name", null)
+  parent_is_private = lookup(each.value, "parent_is_private", false)
+  ns_ttl = lookup(each.value, "ns_ttl", 300)
 
   tags = merge(
     lookup(each.value, "tags", {}),
     var.tags
   )
-}
-
-# If parent zone ID is provided, register delegation NS records in parent zone
-
-locals {
-  ns_zones = var.create ? ({ for zone, value in var.zones:
-    zone => ""
-    if lookup(value, "parent_id", null) != null
-  }) : {}
-}
-
-resource aws_route53_record ns_records {
-  for_each = var.create ? local.ns_zones : {}
-
-  zone_id = var.zones[each.key].parent_id
-  name = each.key
-  type = "NS"
-  ttl = lookup(var.zones[each.key], "ttl", 300)
-  records = aws_route53_zone.this[each.key].name_servers
 }

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,14 +1,14 @@
-output "route53_zone_zone_id" {
-  description = "Zone ID of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.zone_id }
+output "zone_id" {
+  description = "Zone IDs of Route53 zones"
+  value       = { for k, v in module.zone : k => v.zone_id }
 }
 
-output "route53_zone_name_servers" {
-  description = "Name servers of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name_servers }
+output "name_servers" {
+  description = "Name servers of Route53 zones"
+  value       = { for k, v in module.zone : k => v.name_servers }
 }
 
-output "route53_zone_name" {
-  description = "Name of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name }
+output "name" {
+  description = "Names of Route53 zones"
+  value       = { for k, v in module.zone : k => v.name }
 }

--- a/modules/zones/variables.tf
+++ b/modules/zones/variables.tf
@@ -1,9 +1,3 @@
-variable "create" {
-  description = "Whether to create Route53 zone"
-  type        = bool
-  default     = true
-}
-
 variable "zones" {
   description = "Map of Route53 zone parameters"
   type        = any

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = ">= 2.49"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.49"
+    }
   }
 }


### PR DESCRIPTION
## Motivation and Context

When creating a DNS subdomain, you generally need to create an 'NS' record in the parent domain to indicate who is in charge of resolving this domain's elements.

## Description

This PR adds the possibility to create this record automatically. The feature is optional and it is enabled zone by zone. In order to activate it for a given zone, you just need to add a 'parent_id' element in the map defining this zone to create.

## Breaking Changes

When activating the feature, you cannot create a domain and its subdomains in a single module call anymore. You need to create the domain first and, then, call the module again, providing the parent zone id as argument in subdomain(s) definition. See the 'examples' subdirectory for a splitted module call.

No BC break
