### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,24 +19,24 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| cloudfront | terraform-aws-modules/cloudfront/aws |  |
-| disabled_records | ../../modules/records |  |
-| records | ../../modules/records |  |
-| s3_bucket | terraform-aws-modules/s3-bucket/aws |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
-| vpc2 | terraform-aws-modules/vpc/aws |  |
-| zones | ../../modules/zones |  |
+| <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | terraform-aws-modules/cloudfront/aws |  |
+| <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records |  |
+| <a name="module_records"></a> [records](#module\_records) | ../../modules/records |  |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws |  |
+| <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws |  |
+| <a name="module_zones"></a> [zones](#module\_zones) | ../../modules/zones |  |
 
 ## Resources
 
@@ -44,15 +44,15 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_route53\_record\_fqdn | FQDN built using the zone domain and name |
-| this\_route53\_record\_name | The name of the record |
-| this\_route53\_zone\_name | Name of Route53 zone |
-| this\_route53\_zone\_name\_servers | Name servers of Route53 zone |
-| this\_route53\_zone\_zone\_id | Zone ID of Route53 zone |
+| <a name="output_this_route53_record_fqdn"></a> [this\_route53\_record\_fqdn](#output\_this\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
+| <a name="output_this_route53_record_name"></a> [this\_route53\_record\_name](#output\_this\_route53\_record\_name) | The name of the record |
+| <a name="output_this_route53_zone_name"></a> [this\_route53\_zone\_name](#output\_this\_route53\_zone\_name) | Name of Route53 zone |
+| <a name="output_this_route53_zone_name_servers"></a> [this\_route53\_zone\_name\_servers](#output\_this\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_this_route53_zone_zone_id"></a> [this\_route53\_zone\_zone\_id](#output\_this\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -7,40 +7,40 @@ This module creates DNS records in Route53 zone.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
+| Name | Type |
+|------|------|
+| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create | Whether to create DNS records | `bool` | `true` | no |
-| private\_zone | Whether Route53 zone is private or public | `bool` | `false` | no |
-| records | List of maps of DNS records | `any` | `[]` | no |
-| zone\_id | ID of DNS zone | `string` | `null` | no |
-| zone\_name | Name of DNS zone | `string` | `null` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
+| <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_route53\_record\_fqdn | FQDN built using the zone domain and name |
-| this\_route53\_record\_name | The name of the record |
+| <a name="output_this_route53_record_fqdn"></a> [this\_route53\_record\_fqdn](#output\_this\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
+| <a name="output_this_route53_record_name"></a> [this\_route53\_record\_name](#output\_this\_route53\_record\_name) | The name of the record |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -7,38 +7,38 @@ This module creates Route53 zones.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) |
+| Name | Type |
+|------|------|
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create | Whether to create Route53 zone | `bool` | `true` | no |
-| tags | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
-| zones | Map of Route53 zone parameters | `any` | `{}` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Map of Route53 zone parameters | `any` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_route53\_zone\_name | Name of Route53 zone |
-| this\_route53\_zone\_name\_servers | Name servers of Route53 zone |
-| this\_route53\_zone\_zone\_id | Zone ID of Route53 zone |
+| <a name="output_this_route53_zone_name"></a> [this\_route53\_zone\_name](#output\_this\_route53\_zone\_name) | Name of Route53 zone |
+| <a name="output_this_route53_zone_name_servers"></a> [this\_route53\_zone\_name\_servers](#output\_this\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_this_route53_zone_zone_id"></a> [this\_route53\_zone\_zone\_id](#output\_this\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
