### PR TITLE
feat: Add ability for users to create aliases in the same zone

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -122,7 +122,7 @@ module "records" {
       type           = "A"
       set_identifier = "alternative-resource-name"
       alias = {
-        name    = module.s3_bucket.this_s3_bucket_website_domain
+        name = module.s3_bucket.this_s3_bucket_website_domain
       }
     }
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -123,7 +123,6 @@ module "records" {
       set_identifier = "alternative-resource-name"
       alias = {
         name    = module.s3_bucket.this_s3_bucket_website_domain
-        zone_id = null
       }
     }
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -116,6 +116,15 @@ module "records" {
       failover_routing_policy = {
         type = "SECONDARY"
       }
+    },
+    {
+      name           = "alternative-resource-name"
+      type           = "A"
+      set_identifier = "alternative-resource-name"
+      alias = {
+        name    = module.s3_bucket.this_s3_bucket_website_domain
+        zone_id = null
+      }
     }
   ]
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "this" {
 
     content {
       name                   = each.value.alias.name
-      zone_id                = each.value.alias.zone_id
+      zone_id                = try(each.value.alias.zone_id, null) != null ? each.value.alias.zone_id : data.aws_route53_zone.this[0].zone_id
       evaluate_target_health = lookup(each.value.alias, "evaluate_target_health", false)
     }
   }


### PR DESCRIPTION


## Description
With this change users can create aliasses for the same zone as for which the records are being created.
It allows for existing users to keep on using the module without breaking.
If you don't supply a zone_id for your alias record, it now defaults to the zone_id of the zone for which the entry is being created. 

## Motivation and Context
Example of list of records being created by a looped call of the records module:
`{ name = "www.test", type = "A", ttl = null, alias = { name = "test.mydomain.com" } },`

previously this would result in a error since the zone_id in the alias object isn't specified while being required.
In other words this:
`{ name = "www.test", type = "A", ttl = null, alias = { name = "test.mydomain.com" , zone_id = "<id>"} },`
would be allowed while this:
`{ name = "www.test", type = "A", ttl = null, alias = { name = "test.mydomain.com" } },`
would not be allowed

Since the destination zone id of the alias record isn't known in advance (when creating the destination zone via terraform as well) this would require 2 seperate tf runs:
1. To get the zone setup.
2. To get the alias records (with an hardcoded zoneid reference) created.

## Breaking Changes
No this doesn't break backwards compatibility with older versions since it only specifies a default to use when a user doesn't specify an zone_id in the alias record definition.

## How Has This Been Tested?
This change has been tested in a internal project that uses the latest commit on the fork as the zone module source.
For the records where we didn't specify the zone_id of the alias object the default fallback worked successfully.
Meaning that the alias record was created with the automatically retrieved zone id for which the alias record was defined.