### PR TITLE
[fix/inconsistent_types]

### DIFF
--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -12,7 +12,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
+  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? tomap(local.recordsets) : tomap({})
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 


### PR DESCRIPTION
Changed

- wrapped a `local.recordsets` via a `tomap()` function

## Description
There is a need to wrap the `local.recordsets` via a `tomap()` function because of an error message `Error: Inconsistent conditional result types`

## Motivation and Context
After I wanted to add some AWS Route53 records (similar to those in the [examples/complete](https://github.com/terraform-aws-modules/terraform-aws-route53/blob/master/examples/complete/main.tf#L50)) I received below error message

```text
|
│ Error: Inconsistent conditional result types
│
│   on .terraform/modules/records/modules/records/main.tf line 15, in resource "aws_route53_record" "this":
│   15:   for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
│     ├────────────────
│     │ local.recordsets is object with 7 attributes
│
│ The true result value has the wrong type: element types must all match for
│ conversion to map.
|
```

I saw this message in module version `~> 1.0` and `~> 2.0`.

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have tested it with terraform `v0.14.11` and `v0.15.1`
- [x] I have tested it with provider `hashicorp/aws v3.38.0`
