### PR TITLE
Add lifecycle policy on vpc block into the Route53 zone module 

### DIFF
--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -18,4 +18,10 @@ resource "aws_route53_zone" "this" {
     lookup(each.value, "tags", {}),
     var.tags
   )
+
+  lifecycle {
+    ignore_changes = [
+      vpc,
+    ]
+  }
 }


### PR DESCRIPTION
## Description

This PR add a Lifecycle block, with `ignore_changes` for the VPC configuration on Zone Module.
This update is motivated by the Terraform Route53 resource documentation, regarding the private zone: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone#private-zone

## Motivation and Context

We faced an issue using this module with our private R53 zone, and multiple VPC configurations.

As our zone is private, we have to define a VPC block. But then we need to add an other VPC configuration, with an ID from another AWS account.
To do that, we have to use the `aws_route53_vpc_association_authorization` resource, which allows us to associate the VPC_ID to our private R53 zone. But this operation cannot be done before the R53 zone is created.

So we can't define multiple inline VPC configurations, as we need the `association_authorization`;
we can't use only the `aws_route53_zone_association` resource only, as the R53 zone will not be considered as private;
following the Terraform documentation, using both inline & resource association will create `perpetual difference` in our plans.

The only option left, as the doc once again says, is to add a lifecycle block.

## Breaking Changes

There is no really breaking change as the module will still works as it does.
But, any new VPC_association will must be done with the  `aws_route53_zone_association` resource.

## How Has This Been Tested?

I explained how we can to this solution in the `Motivation & Context` block.
We did try to run this PR in our plans, and the VPC update were all gone.
