### PR TITLE
fix: correct for_each expression of aws_route53_record /resolves issue #47

### DIFF
--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -16,7 +16,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
+  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : {}
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 


### PR DESCRIPTION
## Description
It's just a small fix for 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes the issue I've reported - [Inconsistent conditional result types error in resource "aws_route53_record" / module records / terraform1.0.0](https://github.com/terraform-aws-modules/terraform-aws-route53/issues/47).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
It doesn't introduce any breaking changes. The change has been tested for backward compatibility with Terraform 0.14.5.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change has been tested for backward compatibility with Terraform 0.14.5 as well as with 1.0.0 version.
I've just run `terraform plan` and `apply` command using both version against the same module I faced issue with.
