### PR TITLE
Resolve Inconsistent conditional result types error

### DIFF
--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -16,7 +16,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
+  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : []
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 


### PR DESCRIPTION
## Description
Change conditional false type

## Motivation and Context
Resolve:
https://github.com/terraform-aws-modules/terraform-aws-route53/issues/47

```
│ Error: Inconsistent conditional result types
│ 
│   on .terraform/modules/aws_route53_records_zeronorthinternal_com/modules/records/main.tf line 19, in resource "aws_route53_record" "this":
│   19:   for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
│     ├────────────────
│     │ local.recordsets is object with 8 attributes
│ 
│ The true result value has the wrong type: element types must all match for conversion to map.
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
