### PR TITLE
feat: Add geo routing policy and multivalue answer routing policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -65,6 +65,16 @@ module "records" {
       }
     },
     {
+      name           = "geo"
+      type           = "CNAME"
+      ttl            = 5
+      records        = ["europe.test.example.com."]
+      set_identifier = "europe"
+      geolocation_routing_policy = {
+        continent = "EU"
+      }
+    },
+    {
       name = "cloudfront"
       type = "A"
       alias = {
@@ -118,11 +128,11 @@ module "records" {
       }
     },
     {
-      name           = "alternative-resource-name"
-      type           = "A"
-      set_identifier = "alternative-resource-name"
+      name = "alternative-resource-name"
+      type = "A"
       alias = {
-        name = module.s3_bucket.s3_bucket_website_domain
+        name    = module.s3_bucket.s3_bucket_website_domain
+        zone_id = module.s3_bucket.s3_bucket_hosted_zone_id
       }
     }
   ]

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -52,4 +52,14 @@ resource "aws_route53_record" "this" {
       weight = each.value.weighted_routing_policy.weight
     }
   }
+
+  dynamic "geolocation_routing_policy" {
+    for_each = length(keys(lookup(each.value, "geolocation_routing_policy", {}))) == 0 ? [] : [true]
+
+    content {
+      continent   = lookup(each.value.geolocation_routing_policy, "continent", null)
+      country     = lookup(each.value.geolocation_routing_policy, "country", null)
+      subdivision = lookup(each.value.geolocation_routing_policy, "subdivision", null)
+    }
+  }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -20,12 +20,13 @@ resource "aws_route53_record" "this" {
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 
-  name            = each.value.name != "" ? "${each.value.name}.${data.aws_route53_zone.this[0].name}" : data.aws_route53_zone.this[0].name
-  type            = each.value.type
-  ttl             = lookup(each.value, "ttl", null)
-  records         = lookup(each.value, "records", null)
-  set_identifier  = lookup(each.value, "set_identifier", null)
-  health_check_id = lookup(each.value, "health_check_id", null)
+  name                             = each.value.name != "" ? "${each.value.name}.${data.aws_route53_zone.this[0].name}" : data.aws_route53_zone.this[0].name
+  type                             = each.value.type
+  ttl                              = lookup(each.value, "ttl", null)
+  records                          = lookup(each.value, "records", null)
+  set_identifier                   = lookup(each.value, "set_identifier", null)
+  health_check_id                  = lookup(each.value, "health_check_id", null)
+  multivalue_answer_routing_policy = lookup(each.value, "multivalue_answer_routing_policy", null)
 
   dynamic "alias" {
     for_each = length(keys(lookup(each.value, "alias", {}))) == 0 ? [] : [true]


### PR DESCRIPTION
## Description
Supported geolocation routing policy and multivalue answer routing policy in records module.

## Motivation and Context
I'm adding these policies because AWS supports them and I use them. The module doesn't support them before the change.

## Breaking Changes
None

## How Has This Been Tested?
My deployments