### PR TITLE
chore: Updated example with AAAA records for dual-stack CloudFront

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.56.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -20,7 +20,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -90,6 +90,14 @@ module "records" {
       }
     },
     {
+      name = "cloudfront"
+      type = "AAAA"
+      alias = {
+        name    = module.cloudfront.cloudfront_distribution_domain_name
+        zone_id = module.cloudfront.cloudfront_distribution_hosted_zone_id
+      }
+    },
+    {
       name           = "test"
       type           = "CNAME"
       ttl            = 5

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 2.49"

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -7,7 +7,7 @@ This module creates DNS records in Route53 zone.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers

--- a/modules/records/versions.tf
+++ b/modules/records/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 2.49"

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -7,7 +7,7 @@ This module creates Route53 zones.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 2.49"


### PR DESCRIPTION
## Description
Support dual-stack (IPv4 and IPv6) access to the distribution

## Motivation and Context
This example provided only IPv4

## Breaking Changes
none known

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
I employed these changes in my own distribution