### PR TITLE
feat: Allow specifying known values for the keys used to index the recordsets

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -54,6 +54,18 @@ module "records" {
   zone_name = local.zone_name
   #  zone_id = local.zone_id
 
+  record_names = [
+    " A",
+    "s3-bucket A",
+    "geo CNAME europe",
+    "cloudfront A",
+    "cloudfront AAAA",
+    "cloudfront-id CNAME",
+    "test CNAME test-primary",
+    "test CNAME test-secondary",
+    "failover-primary A failover-primary",
+    "failover-secondary A failover-secondary",
+  ]
   records = [
     {
       name = ""
@@ -96,6 +108,13 @@ module "records" {
         name    = module.cloudfront.cloudfront_distribution_domain_name
         zone_id = module.cloudfront.cloudfront_distribution_hosted_zone_id
       }
+    },
+    # test record name depending on module output
+    {
+      name    = "cloudfront-${module.cloudfront.cloudfront_distribution_id}"
+      type    = "CNAME"
+      ttl     = 60
+      records = [module.cloudfront.cloudfront_distribution_domain_name]
     },
     {
       name           = "test"
@@ -183,6 +202,7 @@ module "records_with_terragrunt" {
   #  zone_id = local.zone_id
 
   # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires `records` to be wrapped with `jsonencode()`
+  record_names = ["new A", "s3-bucket-new A"]
   records = jsonencode([
     {
       name = "new"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,18 +63,6 @@ module "records" {
   zone_name = local.zone_name
   #  zone_id = local.zone_id
 
-  record_names = [
-    " A",
-    "s3-bucket A",
-    "geo CNAME europe",
-    "cloudfront A",
-    "cloudfront AAAA",
-    "cloudfront-id CNAME",
-    "test CNAME test-primary",
-    "test CNAME test-secondary",
-    "failover-primary A failover-primary",
-    "failover-secondary A failover-secondary",
-  ]
   records = [
     {
       name = ""
@@ -118,8 +106,10 @@ module "records" {
         zone_id = module.cloudfront.cloudfront_distribution_hosted_zone_id
       }
     },
-    # test record name depending on module output
+    # test record name depending on module output and use map_key
+    # to provide a known key for the internal map
     {
+      map_key = "cloudfront-id"
       name    = "cloudfront-${module.cloudfront.cloudfront_distribution_id}"
       type    = "CNAME"
       ttl     = 60
@@ -210,9 +200,9 @@ module "records_with_terragrunt" {
   zone_name = local.zone_name
   #  zone_id = local.zone_id
 
-  # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires `records` to be wrapped with `jsonencode()`
-  record_names = ["new A", "s3-bucket-new A"]
-  records = jsonencode([
+  # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires JSON encoding of the list of records
+  record_map_keys = ["new A", "s3-bucket-new A"]
+  records_json = jsonencode([
     {
       name = "new"
       type = "A"
@@ -240,8 +230,8 @@ module "records_with_terragrunt_with_lists" {
   zone_name = local.zone_name
   #  zone_id = local.zone_id
 
-  # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires `records` to be wrapped with `jsonencode()`
-  records = jsonencode([
+  # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires JSON encoding of the list of records
+  records_json = jsonencode([
     {
       name = "tg-list1"
       type = "A"

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -33,6 +33,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
+| <a name="input_record_names"></a> [record\_names](#input\_record\_names) | List of unique names for the DNS records | `list(string)` | `[]` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -33,8 +33,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
-| <a name="input_record_names"></a> [record\_names](#input\_record\_names) | List of unique names for the DNS records | `list(string)` | `[]` | no |
+| <a name="input_record_map_keys"></a> [record\_map\_keys](#input\_record\_map\_keys) | List of custom map keys for the internal map. Must have the same length as the records or records\_json variable. May contain null values and the module will generate the key itself | `list(string)` | `[]` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
+| <a name="input_records_json"></a> [records\_json](#input\_records\_json) | JSON encoded list of maps of DNS records | `string` | `null` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -12,10 +12,12 @@ locals {
   # https://github.com/terraform-aws-modules/terraform-aws-route53/issues/47
   # https://github.com/terraform-aws-modules/terraform-aws-route53/pull/39
 
+  record_names = length(var.record_names) > 0 ? var.record_names : [
+    for rs in local.records : join(" ", compact(["${rs.name} ${rs.type}", lookup(rs, "set_identifier", "")]))
+  ]
   recordsets = {
-    for rs in local.records :
-    join(" ", compact(["${rs.name} ${rs.type}", lookup(rs, "set_identifier", "")])) => merge(rs, {
-      records = jsonencode(try(rs.records, null))
+    for i, n in local.record_names : n => merge(local.records[i], {
+      records = jsonencode(try(local.records[i].records, null))
     })
   }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -18,15 +18,13 @@ locals {
   # - build one from the record name, type and optional set_identifier
 
   record_map_keys = length(var.record_map_keys) > 0 ? [
-    for i, n in var.record_map_keys : n != null
-    ? n
-    : lookup(local.records[i], "map_key", join(" ", compact(["${local.records[i].name} ${local.records[i].type}", lookup(local.records[i], "set_identifier", "")])))
+    for i, map_key in var.record_map_keys : try(map_key, local.records[i].map_key, join(" ", compact([local.records[i].name, local.records[i].type, try(local.records[i].set_identifier, "")])))
     ] : [
-    for i, rs in local.records : lookup(rs, "map_key", join(" ", compact(["${rs.name} ${rs.type}", lookup(rs, "set_identifier", "")])))
+    for rs in local.records : try(rs.map_key, join(" ", compact([rs.name, rs.type, try(rs.set_identifier, "")])))
   ]
 
   recordsets = {
-    for i, n in local.record_map_keys : n => merge(local.records[i], {
+    for i, map_key in local.record_map_keys : map_key => merge(local.records[i], {
       records = jsonencode(try(local.records[i].records, null))
     })
   }

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -28,8 +28,14 @@ variable "records" {
   default     = []
 }
 
-variable "record_names" {
-  description = "List of unique names for the DNS records"
+variable "records_json" {
+  description = "JSON encoded list of maps of DNS records"
+  type        = string
+  default     = null
+}
+
+variable "record_map_keys" {
+  description = "List of custom map keys for the internal map. Must have the same length as the records or records_json variable. May contain null values and the module will generate the key itself"
   type        = list(string)
   default     = []
 }

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -27,3 +27,9 @@ variable "records" {
   type        = any
   default     = []
 }
+
+variable "record_names" {
+  description = "List of unique names for the DNS records"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Description
Add an optional variable, `record_names`, to the records module, of type `list(string)`. If the list is not empty, then its values are used as keys of the `local.recordsets` map instead of the keys created by the module from possibly unknown yet values.

## Motivation and Context
The change is a possible solution to issue #59. By allowing the user of the records module to control the map keys, the user can also use the module when the value of name, type of set_identifier depends on resources that have to be created.

## Breaking Changes
There should be no breaking change. The users not affected by the issue can still use `var.records` as before.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects

The complete example can be deployed completely with this change.