### PR TITLE
feat: Allow records with latency routing policy (#67)

### DIFF
--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -77,4 +77,12 @@ resource "aws_route53_record" "this" {
       subdivision = lookup(each.value.geolocation_routing_policy, "subdivision", null)
     }
   }
+  
+  dynamic "latency_routing_policy" {
+    for_each = length(keys(lookup(each.value, "latency_routing_policy", {}))) == 0 ? [] : [true]
+
+    content {
+      region   = lookup(each.value.latency_routing_policy, "region", null)
+    }
+  }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding the option to use the latency `set_identifier` by adding a dynamic `latency_routing_policy` option to the records creation. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The module did not previously allow for the use of latency routing since the routing policy specifying a region is required.
<!--- If it fixes an open issue, please link to the issue here. -->
#67 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This should not cause any breaking changes.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

<!--- Please describe in detail how you tested your changes. -->
I have tested this by adding to the complete example. It seemed to work in as far as getting to the known `Invalid for_each argument` issue. I have also tested these changes using flora-five's fix on the complete example and on my personal project. ~~Everything worked as expected.~~
~~EDIT: hit a snag as seen below...working on a fix~~
I also get the error below when running on the clean flora-five:recordset-keys branch. I'm going to go out on a limb and say that wasn't caused by my changes, and submit this sucker for review.
``` Error: Inconsistent conditional result types
│
│   on ..\..\modules\records\main.tf line 4, in locals:
│    4:   records = var.records_json != null ? jsondecode(var.records_json) : var.records
│     ├────────────────
│     │ var.records is empty tuple
│     │ var.records_json is "[{\"name\":\"new\",\"records\":[\"10.10.10.10\"],\"ttl\":3600,\"type\":\"A\"},{\"alias\":{\"name\":\"s3-website-eu-west-1.amazonaws.com\",\"zone_id\":\"Z1BKCTXD74EZPE\"},\"name\":\"s3-bucket-new\",\"type\":\"A\"}]"
│
│ The true and false result expressions must have consistent types. The given expressions are tuple and tuple,
│ respectively.