### PR TITLE
feat: Added full_override_name override to disable adding domain name to record names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -38,6 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_delegation_sets"></a> [delegation\_sets](#module\_delegation\_sets) | ../../modules/delegation-sets | n/a |
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
+| <a name="module_records_with_full_names"></a> [records\_with\_full\_names](#module\_records\_with\_full\_names) | ../../modules/records | n/a |
 | <a name="module_records_with_lists"></a> [records\_with\_lists](#module\_records\_with\_lists) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt"></a> [records\_with\_terragrunt](#module\_records\_with\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt_with_lists"></a> [records\_with\_terragrunt\_with\_lists](#module\_records\_with\_terragrunt\_with\_lists) | ../../modules/records | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -244,19 +244,30 @@ module "records_with_terragrunt_with_lists" {
   depends_on = [module.zones]
 }
 
+
+
 module "records_with_full_names" {
   source = "../../modules/records"
 
-  zone_name          = "example.com"
-  full_name_override = true
+  zone_name = "example.com"
 
   records = [
     {
       name = "test.example.com"
+      # In case when you need to provide full name of record including domain that is equal zone domain name, use full_name_override = true
+      full_name_override = true
+      type               = "A"
+      ttl                = 3600
+      records = [
+        "10.10.10.10",
+      ]
+    },
+    {
+      name = "web"
       type = "A"
       ttl  = 3600
       records = [
-        "10.10.10.10",
+        "10.10.10.11",
       ]
     },
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -244,6 +244,24 @@ module "records_with_terragrunt_with_lists" {
   depends_on = [module.zones]
 }
 
+module "records_with_full_names" {
+  source = "../../modules/records"
+
+  zone_name          = "example.com"
+  full_name_override = true
+
+  records = [
+    {
+      name = "test.example.com"
+      type = "A"
+      ttl  = 3600
+      records = [
+        "10.10.10.10",
+      ]
+    },
+  ]
+}
+
 module "disabled_records" {
   source = "../../modules/records"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -192,7 +192,7 @@ module "records_with_terragrunt" {
   #  zone_id = local.zone_id
 
   # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires `records` to be wrapped with `jsonencode()`
-  records = jsonencode([
+  records_jsonencoded = jsonencode([
     {
       name = "new"
       type = "A"
@@ -221,7 +221,7 @@ module "records_with_terragrunt_with_lists" {
   #  zone_id = local.zone_id
 
   # Terragrunt has a bug (https://github.com/gruntwork-io/terragrunt/issues/1211) that requires `records` to be wrapped with `jsonencode()`
-  records = jsonencode([
+  records_jsonencoded = jsonencode([
     {
       name = "tg-list1"
       type = "A"
@@ -244,17 +244,14 @@ module "records_with_terragrunt_with_lists" {
   depends_on = [module.zones]
 }
 
-
-
 module "records_with_full_names" {
   source = "../../modules/records"
 
-  zone_name = "example.com"
+  zone_name = local.zone_name
 
   records = [
     {
-      name = "test.example.com"
-      # In case when you need to provide full name of record including domain that is equal zone domain name, use full_name_override = true
+      name               = "with-full-name-override.${local.zone_name}"
       full_name_override = true
       type               = "A"
       ttl                = 3600
@@ -271,6 +268,8 @@ module "records_with_full_names" {
       ]
     },
   ]
+
+  depends_on = [module.zones]
 }
 
 module "disabled_records" {

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -45,3 +45,4 @@ No modules.
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
 | <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -2,6 +2,30 @@
 
 This module creates DNS records in Route53 zone.
 
+Due to a bug in Terragrunt (https://github.com/gruntwork-io/terragrunt/issues/1211), users should specify records using `records_jsonencoded` argument as jsonencode()'d string, like this:
+
+```hcl
+records_jsonencoded = jsonencode([
+  {
+    name = "tg-list1"
+    type = "A"
+    ttl  = 3600
+    records = [
+      "10.10.10.10",
+    ]
+  },
+  {
+    name = "tg-list2"
+    type = "A"
+    ttl  = 3600
+    records = [
+      "20.10.10.10",
+      "30.10.10.10",
+    ]
+  }
+])
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -34,6 +58,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
+| <a name="input_records_jsonencoded"></a> [records\_jsonencoded](#input\_records\_jsonencoded) | List of map of DNS records (stored as jsonencoded string, for terragrunt) | `string` | `null` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |
 

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -32,6 +32,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
+| <a name="input_full_name_override"></a> [full\_name\_override](#input\_full\_name\_override) | When true will override the name of record, will not add the domain name to the record name | `bool` | `false` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -45,4 +45,3 @@ No modules.
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
 | <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -32,7 +32,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create DNS records | `bool` | `true` | no |
-| <a name="input_full_name_override"></a> [full\_name\_override](#input\_full\_name\_override) | When true will override the name of record, will not add the domain name to the record name | `bool` | `false` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of maps of DNS records | `any` | `[]` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -1,7 +1,7 @@
 locals {
   # terragrunt users have to provide `records` as jsonencode()'d string.
   # See details: https://github.com/gruntwork-io/terragrunt/issues/1211
-  records = try(jsondecode(var.records), var.records)
+  records = try(jsondecode(var.records_jsonencoded), var.records)
 
   # Convert `records` from list to map with unique keys
   #
@@ -29,7 +29,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
+  for_each = { for k, v in local.recordsets : k => v if var.create && (var.zone_id != null || var.zone_name != null) }
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -33,7 +33,7 @@ resource "aws_route53_record" "this" {
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 
-  name                             = each.value.name != "" ? (var.full_name_override ? each.value.name : "${each.value.name}.${data.aws_route53_zone.this[0].name}") : data.aws_route53_zone.this[0].name
+  name                             = each.value.name != "" ? (lookup(each.value, "full_name_override", false) ? each.value.name : "${each.value.name}.${data.aws_route53_zone.this[0].name}") : data.aws_route53_zone.this[0].name
   type                             = each.value.type
   ttl                              = lookup(each.value, "ttl", null)
   records                          = jsondecode(each.value.records)

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -33,7 +33,7 @@ resource "aws_route53_record" "this" {
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 
-  name                             = each.value.name != "" ? (var.full_override_name ? each.value.name : "${each.value.name}.${data.aws_route53_zone.this[0].name}") : data.aws_route53_zone.this[0].name
+  name                             = each.value.name != "" ? (var.full_name_override ? each.value.name : "${each.value.name}.${data.aws_route53_zone.this[0].name}") : data.aws_route53_zone.this[0].name
   type                             = each.value.type
   ttl                              = lookup(each.value, "ttl", null)
   records                          = jsondecode(each.value.records)

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -33,7 +33,7 @@ resource "aws_route53_record" "this" {
 
   zone_id = data.aws_route53_zone.this[0].zone_id
 
-  name                             = each.value.name != "" ? "${each.value.name}.${data.aws_route53_zone.this[0].name}" : data.aws_route53_zone.this[0].name
+  name                             = each.value.name != "" ? (var.full_override_name ? each.value.name : "${each.value.name}.${data.aws_route53_zone.this[0].name}") : data.aws_route53_zone.this[0].name
   type                             = each.value.type
   ttl                              = lookup(each.value, "ttl", null)
   records                          = jsondecode(each.value.records)

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -28,7 +28,7 @@ variable "records" {
   default     = []
 }
 
-variable "full_override_name" {
+variable "full_name_override" {
   description = "When true will override the name of record, will not add the domain name to the record name"
   type        = bool
   default     = false

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -27,3 +27,9 @@ variable "records" {
   type        = any
   default     = []
 }
+
+variable "records_jsonencoded" {
+  description = "List of map of DNS records (stored as jsonencoded string, for terragrunt)"
+  type        = string
+  default     = null
+}

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -27,9 +27,3 @@ variable "records" {
   type        = any
   default     = []
 }
-
-variable "full_name_override" {
-  description = "When true will override the name of record, will not add the domain name to the record name"
-  type        = bool
-  default     = false
-}

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -27,3 +27,9 @@ variable "records" {
   type        = any
   default     = []
 }
+
+variable "full_override_name" {
+  description = "When true will override the name of record, will not add the domain name to the record name"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
…efix to the record name

## Description
add full_override_name override to disable adding domain name as a prefix to the record name

## Motivation and Context
add possibility to read the exported dns file taht contains full names.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
