### PR TITLE
feat: Add resolver rule association module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ There are independent submodules:
 - [zones](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zones) - to manage Route53 zones
 - [records](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/records) - to manage Route53 records
 - [delegation-sets](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/delegation-sets) - to manage Route53 delegation sets
+- [resolver-rule-associations](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/resolver-rule-associations) - to manage Route53 resolver rule associations
 
 ## Usage
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -41,7 +41,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_records_with_lists"></a> [records\_with\_lists](#module\_records\_with\_lists) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt"></a> [records\_with\_terragrunt](#module\_records\_with\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt_with_lists"></a> [records\_with\_terragrunt\_with\_lists](#module\_records\_with\_terragrunt\_with\_lists) | ../../modules/records | n/a |
-| <a name="module_resolver-rule-associations"></a> [resolver-rule-associations](#module\_resolver-rule-associations) | ../../modules/resolver-rule-associations | n/a |
+| <a name="module_resolver_rule_associations"></a> [resolver_rule_associations](#module\_resolver_rule_associations) | ../../modules/resolver_rule_associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | n/a |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -42,7 +42,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_records_with_lists"></a> [records\_with\_lists](#module\_records\_with\_lists) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt"></a> [records\_with\_terragrunt](#module\_records\_with\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt_with_lists"></a> [records\_with\_terragrunt\_with\_lists](#module\_records\_with\_terragrunt\_with\_lists) | ../../modules/records | n/a |
-| <a name="module_resolver_rule_associations"></a> [resolver_rule_associations](#module\_resolver_rule_associations) | ../../modules/resolver_rule_associations | n/a |
+| <a name="module_resolver_rule_associations"></a> [resolver\_rule\_associations](#module\_resolver\_rule\_associations) | ../../modules/resolver-rule-associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | n/a |
@@ -63,13 +63,13 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_route53_resolver_rule_association_id"></a> [aws\_route53\_resolver\_rule\_association\_id](#output\_aws\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
-| <a name="output_aws_route53_resolver_rule_association_name"></a> [aws\_route53\_resolver\_rule\_association\_name](#output\_aws\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
-| <a name="output_aws_route53_resolver_rule_association_resolver_rule_id"></a> [aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
 | <a name="output_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#output\_route53\_delegation\_set\_id) | ID of Route53 delegation set |
 | <a name="output_route53_delegation_set_name_servers"></a> [route53\_delegation\_set\_name\_servers](#output\_route53\_delegation\_set\_name\_servers) | Name servers in the Route53 delegation set |
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
 | <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
+| <a name="output_route53_resolver_rule_association_id"></a> [route53\_resolver\_rule\_association\_id](#output\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
+| <a name="output_route53_resolver_rule_association_name"></a> [route53\_resolver\_rule\_association\_name](#output\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
+| <a name="output_route53_resolver_rule_association_resolver_rule_id"></a> [route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
 | <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -41,6 +41,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_records_with_lists"></a> [records\_with\_lists](#module\_records\_with\_lists) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt"></a> [records\_with\_terragrunt](#module\_records\_with\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_records_with_terragrunt_with_lists"></a> [records\_with\_terragrunt\_with\_lists](#module\_records\_with\_terragrunt\_with\_lists) | ../../modules/records | n/a |
+| <a name="module_resolver-rule-associations"></a> [resolver-rule-associations](#module\_resolver-rule-associations) | ../../modules/resolver-rule-associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | n/a |
@@ -51,6 +52,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [aws_route53_health_check.failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
+| [aws_route53_resolver_rule.sys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
 
 ## Inputs
 
@@ -60,6 +62,9 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_route53_resolver_rule_association_id"></a> [aws\_route53\_resolver\_rule\_association\_id](#output\_aws\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
+| <a name="output_aws_route53_resolver_rule_association_name"></a> [aws\_route53\_resolver\_rule\_association\_name](#output\_aws\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
+| <a name="output_aws_route53_resolver_rule_association_resolver_rule_id"></a> [aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
 | <a name="output_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#output\_route53\_delegation\_set\_id) | ID of Route53 delegation set |
 | <a name="output_route53_delegation_set_name_servers"></a> [route53\_delegation\_set\_name\_servers](#output\_route53\_delegation\_set\_name\_servers) | Name servers in the Route53 delegation set |
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,7 +26,7 @@ module "resolver-rule-associations" {
     },
     "example2" = {
       resolver_rule_id = aws_route53_resolver_rule.sys.id
-      vpc_id = module.vpc2.vpc_id
+      vpc_id           = module.vpc2.vpc_id
     },
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,7 +15,7 @@ module "delegation_sets" {
   }
 }
 
-module "resolver-rule-associations" {
+module "resolver_rule_associations" {
   source = "../../modules/resolver-rule-associations"
 
   vpc_id = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,32 +7,6 @@ locals {
   #  zone_id = module.zones.route53_zone_zone_id["app.terraform-aws-modules-example.com"]
 }
 
-module "delegation_sets" {
-  source = "../../modules/delegation-sets"
-
-  delegation_sets = {
-    main = {}
-  }
-}
-
-module "resolver_rule_associations" {
-  source = "../../modules/resolver-rule-associations"
-
-  vpc_id = module.vpc.vpc_id
-
-  resolver_rule_associations = {
-    "example" = {
-      name             = "example"
-      resolver_rule_id = aws_route53_resolver_rule.sys.id
-    },
-    "example2" = {
-      name             = "example2"
-      resolver_rule_id = aws_route53_resolver_rule.sys.id
-      vpc_id           = module.vpc2.vpc_id
-    },
-  }
-}
-
 module "zones" {
   source = "../../modules/zones"
 
@@ -289,6 +263,32 @@ module "records_with_full_names" {
 
   depends_on = [module.zones]
 }
+
+module "delegation_sets" {
+  source = "../../modules/delegation-sets"
+
+  delegation_sets = {
+    main = {}
+  }
+}
+
+module "resolver_rule_associations" {
+  source = "../../modules/resolver-rule-associations"
+
+  vpc_id = module.vpc.vpc_id
+
+  resolver_rule_associations = {
+    example = {
+      resolver_rule_id = aws_route53_resolver_rule.sys.id
+    },
+    example2 = {
+      name             = "example2"
+      resolver_rule_id = aws_route53_resolver_rule.sys.id
+      vpc_id           = module.vpc2.vpc_id
+    },
+  }
+}
+
 
 module "disabled_records" {
   source = "../../modules/records"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,6 +15,22 @@ module "delegation_sets" {
   }
 }
 
+module "resolver-rule-associations" {
+  source = "../../modules/resolver-rule-associations"
+
+  vpc_id = module.vpc.vpc_id
+
+  resolver_rule_associations = {
+    "example" = {
+      resolver_rule_id = aws_route53_resolver_rule.sys.id
+    },
+    "example2" = {
+      resolver_rule_id = aws_route53_resolver_rule.sys.id
+      vpc_id = module.vpc2.vpc_id
+    },
+  }
+}
+
 module "zones" {
   source = "../../modules/zones"
 
@@ -308,4 +324,9 @@ module "vpc2" {
 
   name = "my-second-vpc-for-private-route53-zone"
   cidr = "10.1.0.0/16"
+}
+
+resource "aws_route53_resolver_rule" "sys" {
+  domain_name = "sys-example.com"
+  rule_type   = "SYSTEM"
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,9 +22,11 @@ module "resolver-rule-associations" {
 
   resolver_rule_associations = {
     "example" = {
+      name             = "example"
       resolver_rule_id = aws_route53_resolver_rule.sys.id
     },
     "example2" = {
+      name             = "example2"
       resolver_rule_id = aws_route53_resolver_rule.sys.id
       vpc_id           = module.vpc2.vpc_id
     },

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,30 +1,3 @@
-# delegation sets
-output "route53_delegation_set_id" {
-  description = "ID of Route53 delegation set"
-  value       = module.delegation_sets.route53_delegation_set_id
-}
-
-output "route53_delegation_set_name_servers" {
-  description = "Name servers in the Route53 delegation set"
-  value       = module.delegation_sets.route53_delegation_set_name_servers
-}
-
-# resolver rule associations
-output "aws_route53_resolver_rule_association_id" {
-  description = "ID of Route53 Resolver rule associations"
-  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_id
-}
-
-output "aws_route53_resolver_rule_association_name" {
-  description = "Name of Route53 Resolver rule associations"
-  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_name
-}
-
-output "aws_route53_resolver_rule_association_resolver_rule_id" {
-  description = "ID of Route53 Resolver rule associations resolver rule"
-  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_resolver_rule_id
-}
-
 # zones
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"
@@ -50,4 +23,31 @@ output "route53_record_name" {
 output "route53_record_fqdn" {
   description = "FQDN built using the zone domain and name"
   value       = module.records.route53_record_fqdn
+}
+
+# delegation sets
+output "route53_delegation_set_id" {
+  description = "ID of Route53 delegation set"
+  value       = module.delegation_sets.route53_delegation_set_id
+}
+
+output "route53_delegation_set_name_servers" {
+  description = "Name servers in the Route53 delegation set"
+  value       = module.delegation_sets.route53_delegation_set_name_servers
+}
+
+# resolver rule associations
+output "route53_resolver_rule_association_id" {
+  description = "ID of Route53 Resolver rule associations"
+  value       = module.resolver_rule_associations.route53_resolver_rule_association_id
+}
+
+output "route53_resolver_rule_association_name" {
+  description = "Name of Route53 Resolver rule associations"
+  value       = module.resolver_rule_associations.route53_resolver_rule_association_name
+}
+
+output "route53_resolver_rule_association_resolver_rule_id" {
+  description = "ID of Route53 Resolver rule associations resolver rule"
+  value       = module.resolver_rule_associations.route53_resolver_rule_association_resolver_rule_id
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -12,17 +12,17 @@ output "route53_delegation_set_name_servers" {
 # resolver rule associations
 output "aws_route53_resolver_rule_association_id" {
   description = "ID of Route53 Resolver rule associations"
-  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_id
+  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_id
 }
 
 output "aws_route53_resolver_rule_association_name" {
   description = "Name of Route53 Resolver rule associations"
-  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_name
+  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_name
 }
 
 output "aws_route53_resolver_rule_association_resolver_rule_id" {
   description = "ID of Route53 Resolver rule associations resolver rule"
-  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_resolver_rule_id
+  value       = module.resolver_rule_associations.aws_route53_resolver_rule_association_resolver_rule_id
 }
 
 # zones

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -9,6 +9,22 @@ output "route53_delegation_set_name_servers" {
   value       = module.delegation_sets.route53_delegation_set_name_servers
 }
 
+# resolver rule associations
+output "aws_route53_resolver_rule_association_id" {
+  description = "ID of Route53 Resolver rule associations"
+  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_id
+}
+
+output "aws_route53_resolver_rule_association_name" {
+  description = "Name of Route53 Resolver rule associations"
+  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_name
+}
+
+output "aws_route53_resolver_rule_association_resolver_rule_id" {
+  description = "ID of Route53 Resolver rule associations resolver rule"
+  value       = module.resolver-rule-associations.aws_route53_resolver_rule_association_resolver_rule_id
+}
+
 # zones
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -1,0 +1,66 @@
+# Route53 Resolver Rule Associations
+
+This module creates Route53 resolver rule associations.
+
+## Usage
+
+### Create Route53 Resolver rule associations
+
+```hcl
+module "resolver_rule_associations" {
+  source  = "terraform-aws-modules/route53/aws//modules/resolver-rule-associations"
+  version = "~> 2.0"
+
+  vpc_id = "vpc-..."
+
+  resolver_rule_associations = {
+    "myass-foo" = {
+      resolver_rule_id = "rslvr-rr-..."
+    },
+    "myass-bar" = {
+      resolver_rule_id = "rslvr-rr-..."
+    },
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_resolver_rule_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 Resolver rule associations | `bool` | `true` | no |
+| <a name="input_resolver_rule_associations"></a> [resolver\_rule\_associations](#input\_resolver\_rule\_associations) | Map of Route53 Resolver rule associations parameters | `any` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Default VPC ID for all the Route53 Resolver rule associations | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_route53_resolver_rule_association_id"></a> [aws\_route53\_resolver\_rule\_association\_id](#output\_aws\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
+| <a name="output_aws_route53_resolver_rule_association_name"></a> [aws\_route53\_resolver\_rule\_association\_name](#output\_aws\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
+| <a name="output_aws_route53_resolver_rule_association_resolver_rule_id"></a> [aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -11,14 +11,16 @@ module "resolver_rule_associations" {
   source  = "terraform-aws-modules/route53/aws//modules/resolver-rule-associations"
   version = "~> 2.0"
 
-  vpc_id = "vpc-..."
+  vpc_id = "vpc-185a3e2f2d6d2c863"
 
   resolver_rule_associations = {
-    "myass-foo" = {
-      resolver_rule_id = "rslvr-rr-..."
+    foo = {
+      resolver_rule_id = "rslvr-rr-2d3e8e42eea14f20a"
     },
-    "myass-bar" = {
-      resolver_rule_id = "rslvr-rr-..."
+    bar = {
+      name             = "bar"
+      resolver_rule_id = "rslvr-rr-2d3e8e42eea14f20a"
+      vpc_id           = "vpc-285a3e2f2d6d2c863"
     },
   }
 }

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -60,7 +60,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_route53_resolver_rule_association_id"></a> [aws\_route53\_resolver\_rule\_association\_id](#output\_aws\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
-| <a name="output_aws_route53_resolver_rule_association_name"></a> [aws\_route53\_resolver\_rule\_association\_name](#output\_aws\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
-| <a name="output_aws_route53_resolver_rule_association_resolver_rule_id"></a> [aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_aws\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
+| <a name="output_route53_resolver_rule_association_id"></a> [route53\_resolver\_rule\_association\_id](#output\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
+| <a name="output_route53_resolver_rule_association_name"></a> [route53\_resolver\_rule\_association\_name](#output\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
+| <a name="output_route53_resolver_rule_association_resolver_rule_id"></a> [route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/resolver-rule-associations/main.tf
+++ b/modules/resolver-rule-associations/main.tf
@@ -3,5 +3,5 @@ resource "aws_route53_resolver_rule_association" "this" {
 
   name             = try(each.value.name, null)
   vpc_id           = try(each.value.vpc_id, var.vpc_id)
-  resolver_rule_id = lookup(each.value, "resolver_rule_id", null)
+  resolver_rule_id = each.value.resolver_rule_id
 }

--- a/modules/resolver-rule-associations/main.tf
+++ b/modules/resolver-rule-associations/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_resolver_rule_association" "this" {
+  for_each = var.create ? var.resolver_rule_associations : tomap({})
+
+  name             = try(each.value.name, each.key, null)
+  vpc_id           = try(each.value.vpc_id, var.vpc_id)
+  resolver_rule_id = lookup(each.value, "resolver_rule_id", null)
+}

--- a/modules/resolver-rule-associations/main.tf
+++ b/modules/resolver-rule-associations/main.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_resolver_rule_association" "this" {
   for_each = var.create ? var.resolver_rule_associations : tomap({})
 
-  name             = try(each.value.name, each.key, null)
+  name             = try(each.value.name, null)
   vpc_id           = try(each.value.vpc_id, var.vpc_id)
   resolver_rule_id = lookup(each.value, "resolver_rule_id", null)
 }

--- a/modules/resolver-rule-associations/main.tf
+++ b/modules/resolver-rule-associations/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_resolver_rule_association" "this" {
-  for_each = var.create ? var.resolver_rule_associations : tomap({})
+  for_each = { for k, v in var.resolver_rule_associations : k => v if var.create }
 
   name             = try(each.value.name, null)
   vpc_id           = try(each.value.vpc_id, var.vpc_id)

--- a/modules/resolver-rule-associations/outputs.tf
+++ b/modules/resolver-rule-associations/outputs.tf
@@ -1,0 +1,14 @@
+output "aws_route53_resolver_rule_association_id" {
+  description = "ID of Route53 Resolver rule associations"
+  value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.id }
+}
+
+output "aws_route53_resolver_rule_association_name" {
+  description = "Name of Route53 Resolver rule associations"
+  value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.name }
+}
+
+output "aws_route53_resolver_rule_association_resolver_rule_id" {
+  description = "ID of Route53 Resolver rule associations resolver rule"
+  value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.resolver_rule_id }
+}

--- a/modules/resolver-rule-associations/outputs.tf
+++ b/modules/resolver-rule-associations/outputs.tf
@@ -1,14 +1,14 @@
-output "aws_route53_resolver_rule_association_id" {
+output "route53_resolver_rule_association_id" {
   description = "ID of Route53 Resolver rule associations"
   value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.id }
 }
 
-output "aws_route53_resolver_rule_association_name" {
+output "route53_resolver_rule_association_name" {
   description = "Name of Route53 Resolver rule associations"
   value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.name }
 }
 
-output "aws_route53_resolver_rule_association_resolver_rule_id" {
+output "route53_resolver_rule_association_resolver_rule_id" {
   description = "ID of Route53 Resolver rule associations resolver rule"
   value       = { for k, v in aws_route53_resolver_rule_association.this : k => v.resolver_rule_id }
 }

--- a/modules/resolver-rule-associations/variables.tf
+++ b/modules/resolver-rule-associations/variables.tf
@@ -1,0 +1,17 @@
+variable "create" {
+  description = "Whether to create Route53 Resolver rule associations"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "Default VPC ID for all the Route53 Resolver rule associations"
+  type        = string
+  default     = null
+}
+
+variable "resolver_rule_associations" {
+  description = "Map of Route53 Resolver rule associations parameters"
+  type        = any
+  default     = {}
+}

--- a/modules/resolver-rule-associations/versions.tf
+++ b/modules/resolver-rule-associations/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = ">= 3.56"
+  }
+}


### PR DESCRIPTION
## Description
Resolver rule association module was added

## Motivation and Context
It is used to create one or more resolver rule associations

## Breaking Changes
Clear addition

## How Has This Been Tested?
- tflint
- terraform fmt
- real resolver rule associations created