### PR TITLE
feat(records): Add support for latency routing policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -143,6 +143,19 @@ module "records" {
       failover_routing_policy = {
         type = "SECONDARY"
       }
+    },
+    {
+      name           = "latency-test"
+      type           = "A"
+      set_identifier = "latency-test"
+      alias = {
+        name                   = module.cloudfront.cloudfront_distribution_domain_name
+        zone_id                = module.cloudfront.cloudfront_distribution_hosted_zone_id
+        evaluate_target_health = true
+      }
+      latency_routing_policy = {
+        region = "eu-west-1"
+      }
     }
   ]
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -47,6 +47,14 @@ resource "aws_route53_record" "this" {
     }
   }
 
+  dynamic "latency_routing_policy" {
+    for_each = length(keys(lookup(each.value, "latency_routing_policy", {}))) == 0 ? [] : [true]
+
+    content {
+      region = each.value.latency_routing_policy.region
+    }
+  }
+
   dynamic "weighted_routing_policy" {
     for_each = length(keys(lookup(each.value, "weighted_routing_policy", {}))) == 0 ? [] : [true]
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
It will add support for latency routing policies for `records` module

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Useful when having resources in multiple AWS Regions and you want to route traffic to the region that provides the best latency. You can use latency routing to create records in a private hosted zone too.
The feature is already supported by the resource.
It closes #75 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
