### PR TITLE
feat: Add vpc association authorization flow (for cross account access to private zone)

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,7 +44,10 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_terragrunt"></a> [terragrunt](#module\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | n/a |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc_other_account"></a> [vpc\_other\_account](#module\_vpc\_other\_account) | terraform-aws-modules/vpc/aws | n/a |
 | <a name="module_zones"></a> [zones](#module\_zones) | ../../modules/zones | n/a |
+| <a name="module_zones_associations"></a> [zones\_associations](#module\_zones\_associations) | ../../modules/zones_associations | n/a |
+| <a name="module_zones_associations_other_account"></a> [zones\_associations\_other\_account](#module\_zones\_associations\_other\_account) | ../../modules/zones_associations | n/a |
 
 ## Resources
 

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -24,7 +24,9 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_route53_vpc_association_authorization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_vpc_association_authorization) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.with_external_vpcs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 
 ## Inputs
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,5 +1,10 @@
+locals {
+  vpc_association_authorization = flatten([for k, v in var.zones : [for vpc in lookup(v, "external_vpcs", []) : { zone_key = k, vpc_id = vpc.vpc_id, vpc_region = lookup(vpc, "vpc_region", null) }] if var.create])
+  zones_with_external_vpcs      = { for k, v in var.zones : k => v if(lookup(v, "external_vpcs", false) != false && var.create) }
+  zones_without_external_vpcs   = { for k, v in var.zones : k => v if(lookup(v, "external_vpcs", false) == false && var.create) }
+}
 resource "aws_route53_zone" "this" {
-  for_each = { for k, v in var.zones : k => v if var.create }
+  for_each = local.zones_without_external_vpcs
 
   name          = lookup(each.value, "domain_name", each.key)
   comment       = lookup(each.value, "comment", null)
@@ -20,4 +25,36 @@ resource "aws_route53_zone" "this" {
     lookup(each.value, "tags", {}),
     var.tags
   )
+}
+resource "aws_route53_zone" "with_external_vpcs" {
+  for_each = local.zones_with_external_vpcs
+
+  name          = lookup(each.value, "domain_name", each.key)
+  comment       = lookup(each.value, "comment", null)
+  force_destroy = lookup(each.value, "force_destroy", false)
+
+  delegation_set_id = lookup(each.value, "delegation_set_id", null)
+
+  dynamic "vpc" {
+    for_each = try(tolist(lookup(each.value, "vpc", [])), [lookup(each.value, "vpc", {})])
+
+    content {
+      vpc_id     = vpc.value.vpc_id
+      vpc_region = lookup(vpc.value, "vpc_region", null)
+    }
+  }
+
+  tags = merge(
+    lookup(each.value, "tags", {}),
+    var.tags
+  )
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}
+resource "aws_route53_vpc_association_authorization" "this" {
+  count      = length(local.vpc_association_authorization)
+  zone_id    = aws_route53_zone.with_external_vpcs[local.vpc_association_authorization[count.index].zone_key].id
+  vpc_id     = local.vpc_association_authorization[count.index].vpc_id
+  vpc_region = local.vpc_association_authorization[count.index].vpc_region
 }

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,14 +1,14 @@
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.zone_id }
+  value       = { for k, v in merge(aws_route53_zone.this, aws_route53_zone.with_external_vpcs) : k => v.zone_id }
 }
 
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name_servers }
+  value       = { for k, v in merge(aws_route53_zone.this, aws_route53_zone.with_external_vpcs) : k => v.name_servers }
 }
 
 output "route53_zone_name" {
   description = "Name of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name }
+  value       = { for k, v in merge(aws_route53_zone.this, aws_route53_zone.with_external_vpcs) : k => v.name }
 }

--- a/modules/zones_associations/README.md
+++ b/modules/zones_associations/README.md
@@ -1,0 +1,41 @@
+# Route53 Zones Associations
+
+This module creates Route53 zones associations.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_zone_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
+| <a name="input_zones_associations"></a> [zones\_associations](#input\_zones\_associations) | List of map of Route53 zone association parameters | `list(map(any))` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_route53_zones_associations"></a> [aws\_route53\_zones\_associations](#output\_aws\_route53\_zones\_associations) | Zones associations of Route53 zone and VPCs |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zones_associations/main.tf
+++ b/modules/zones_associations/main.tf
@@ -1,0 +1,6 @@
+resource "aws_route53_zone_association" "this" {
+  count      = var.create ? length(var.zones_associations) : 0
+  zone_id    = var.zones_associations[count.index]["zone_id"]
+  vpc_id     = var.zones_associations[count.index]["vpc_id"]
+  vpc_region = lookup(var.zones_associations[count.index], "vpc_region", null)
+}

--- a/modules/zones_associations/outputs.tf
+++ b/modules/zones_associations/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_route53_zones_associations" {
+  description = "Zones associations of Route53 zone and VPCs"
+  value       = aws_route53_zone_association.this
+}

--- a/modules/zones_associations/variables.tf
+++ b/modules/zones_associations/variables.tf
@@ -1,0 +1,11 @@
+variable "create" {
+  description = "Whether to create Route53 zone"
+  type        = bool
+  default     = true
+}
+
+variable "zones_associations" {
+  description = "List of map of Route53 zone association parameters"
+  type        = list(map(any))
+  default     = []
+}

--- a/modules/zones_associations/versions.tf
+++ b/modules/zones_associations/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = ">= 2.49"
+  }
+}


### PR DESCRIPTION
## Description
Adding an extra parameter to the existing `zones` variable in the `zone` module to split same AWS account from others AWS accounts owned VPCs 

## Motivation and Context
It allows use of this module to initiate a VPC association if the VPC is in another account than the Route53 private zone.
The secondary new module allows to complete that association.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seems to fix https://github.com/terraform-aws-modules/terraform-aws-route53/issues/77
I didn't check issues upfront

## Breaking Changes
It does not break compatibility with previous releases

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
