### PR TITLE
chore: Add example for MX and TXT records

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -156,6 +156,18 @@ module "records" {
       latency_routing_policy = {
         region = "eu-west-1"
       }
+    },
+    {
+      name    = "_dmarc"
+      type    = "TXT"
+      ttl     = 14400
+      records = ["v=DMARC1;p=quarantine;pct=100;sp=none;aspf=s;"]
+    },
+    {
+      name    = "mail"
+      type    = "MX"
+      ttl     = 14400
+      records = ["0  example.mail.protection.outlook.com."]
     }
   ]
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add working example for MX and TXT records.
Fixes #79 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I wanted to add more records type as examples.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
