### PR TITLE
feat: Add zone ARN to outputs

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -70,5 +70,6 @@ No inputs.
 | <a name="output_route53_resolver_rule_association_resolver_rule_id"></a> [route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_route53_zone_zone_arn"></a> [route53\_zone\_zone\_arn](#output\_route53\_zone\_zone\_arn) | Zone ARN of Route53 zone |
 | <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -4,6 +4,11 @@ output "route53_zone_zone_id" {
   value       = module.zones.route53_zone_zone_id
 }
 
+output "route53_zone_zone_arn" {
+  description = "Zone ARN of Route53 zone"
+  value       = module.zones.route53_zone_zone_arn
+}
+
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
   value       = module.zones.route53_zone_name_servers

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -40,5 +40,6 @@ No modules.
 |------|-------------|
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
+| <a name="output_route53_zone_zone_arn"></a> [route53\_zone\_zone\_arn](#output\_route53\_zone\_zone\_arn) | Zone ARN of Route53 zone |
 | <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -3,6 +3,11 @@ output "route53_zone_zone_id" {
   value       = { for k, v in aws_route53_zone.this : k => v.zone_id }
 }
 
+output "route53_zone_zone_arn" {
+  description = "Zone ARN of Route53 zone"
+  value       = { for k, v in aws_route53_zone.this : k => v.arn }
+}
+
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
   value       = { for k, v in aws_route53_zone.this : k => v.name_servers }


### PR DESCRIPTION
## Description
Add the route53 zone ARN to outputs.

## Motivation and Context
ARN is needed in other modules.

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
