### PR TITLE
feat: Ability to enable DNSSEC for Route53 zone

### DIFF
--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -33,6 +33,8 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Map of Route53 zone parameters | `any` | `{}` | no |
+| <a name="input_dnssec"></a> [dnssec](#input\_dnssec) | Parameter of the <a name="input_zones"></a> [zones](#input\_zones) input, determining if DNSSEC for Route53 zone enabled | `string` | null | no |
+| <a name="input_ksk"></a> [ksk](#input\_ksk) | Parameter of the <a name="input_zones"></a> [zones](#input\_zones) input, KMS key's ARN, determining previously created KMS key usage as key signing key (KSK) | `string` | null | no |
 
 ## Outputs
 

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -24,7 +24,11 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_route53_hosted_zone_dnssec.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_hosted_zone_dnssec) | resource |
+| [aws_route53_key_signing_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_key_signing_key) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
@@ -33,8 +37,6 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 zone | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags added to all zones. Will take precedence over tags from the 'zones' variable | `map(any)` | `{}` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Map of Route53 zone parameters | `any` | `{}` | no |
-| <a name="input_dnssec"></a> [dnssec](#input\_dnssec) | Parameter of the <a name="input_zones"></a> [zones](#input\_zones) input, determining if DNSSEC for Route53 zone enabled | `string` | null | no |
-| <a name="input_ksk"></a> [ksk](#input\_ksk) | Parameter of the <a name="input_zones"></a> [zones](#input\_zones) input, KMS key's ARN, determining previously created KMS key usage as key signing key (KSK) | `string` | null | no |
 
 ## Outputs
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -17,7 +17,7 @@ resource "aws_route53_zone" "this" {
       vpc_region = lookup(vpc.value, "vpc_region", null)
     }
   }
-  
+
   tags = merge(
     lookup(each.value, "tags", {}),
     var.tags
@@ -26,11 +26,11 @@ resource "aws_route53_zone" "this" {
 
 resource "aws_kms_key" "this" {
   for_each = {
-    for k, v in var.zones : 
-    k => v 
+    for k, v in var.zones :
+    k => v
     if var.create
     && lookup(v, "dnssec", null) == "enable"
-    && lookup(v, "ksk", null) == null 
+    && lookup(v, "ksk", null) == null
   }
 
   customer_master_key_spec = "ECC_NIST_P256"
@@ -73,8 +73,8 @@ resource "aws_kms_key" "this" {
 
 resource "aws_route53_key_signing_key" "this" {
   for_each = {
-    for k, v in var.zones : 
-    k => v 
+    for k, v in var.zones :
+    k => v
     if var.create
     && lookup(v, "dnssec", null) == "enable"
   }
@@ -86,8 +86,8 @@ resource "aws_route53_key_signing_key" "this" {
 
 resource "aws_route53_hosted_zone_dnssec" "this" {
   for_each = {
-    for k, v in var.zones : 
-    k => v 
+    for k, v in var.zones :
+    k => v
     if var.create
     && lookup(v, "dnssec", null) == "enable"
   }

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,5 +1,4 @@
 data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 
 resource "aws_route53_zone" "this" {
   for_each = { for k, v in var.zones : k => v if var.create }

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 resource "aws_route53_zone" "this" {
   for_each = { for k, v in var.zones : k => v if var.create }
 
@@ -15,9 +18,83 @@ resource "aws_route53_zone" "this" {
       vpc_region = lookup(vpc.value, "vpc_region", null)
     }
   }
+  
+  tags = merge(
+    lookup(each.value, "tags", {}),
+    var.tags
+  )
+}
+
+resource "aws_kms_key" "this" {
+  for_each = {
+    for k, v in var.zones : 
+    k => v 
+    if var.create
+    && lookup(v, "dnssec", null) == "enable"
+    && lookup(v, "ksk", null) == null 
+  }
+
+  customer_master_key_spec = "ECC_NIST_P256"
+  deletion_window_in_days  = 7
+  key_usage                = "SIGN_VERIFY"
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "kms:DescribeKey",
+          "kms:GetPublicKey",
+          "kms:Sign",
+          "kms:Verify",
+        ],
+        Effect = "Allow"
+        Principal = {
+          Service = "dnssec-route53.amazonaws.com"
+        }
+        Resource = "*"
+        Sid      = "Allow Route 53 DNSSEC Service for ${lookup(each.value, "domain_name", each.key)}",
+      },
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions for ${lookup(each.value, "domain_name", each.key)}"
+      },
+    ]
+    Version = "2012-10-17"
+  })
 
   tags = merge(
     lookup(each.value, "tags", {}),
     var.tags
   )
+}
+
+resource "aws_route53_key_signing_key" "this" {
+  for_each = {
+    for k, v in var.zones : 
+    k => v 
+    if var.create
+    && lookup(v, "dnssec", null) == "enable"
+  }
+
+  hosted_zone_id             = aws_route53_zone.this["${each.key}"].id
+  key_management_service_arn = !(length(lookup(each.value, "ksk", "")) > 0) ? try(aws_kms_key.this["${each.key}"].arn, null) : try(var.zones["${each.key}"].ksk, null)
+  name                       = aws_route53_zone.this["${each.key}"].name
+}
+
+resource "aws_route53_hosted_zone_dnssec" "this" {
+  for_each = {
+    for k, v in var.zones : 
+    k => v 
+    if var.create
+    && lookup(v, "dnssec", null) == "enable"
+  }
+
+  depends_on = [
+    aws_route53_key_signing_key.this
+  ]
+  hosted_zone_id = aws_route53_key_signing_key.this["${each.key}"].hosted_zone_id
 }


### PR DESCRIPTION
## Description
Improve the zones module with the ability to enable DNSSEC for the Route53 zone

## Motivation and Context
DNSSEC support was already [released](https://aws.amazon.com/about-aws/whats-new/2020/12/announcing-amazon-route-53-support-dnssec/) a long time ago, so it is a convenient and useful addition to the module. Moreover, earlier there was a [request](https://github.com/terraform-aws-modules/terraform-aws-route53/issues/57) to add this feature to the module.

## Breaking Changes
There are no critical changes. Just a little bit of empowerment

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
