### PR TITLE
feat!: Add support for geoproximity routing policy. Upgraded TF version to 1.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.91.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are independent submodules:
 ```hcl
 module "zones" {
   source  = "terraform-aws-modules/route53/aws//modules/zones"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   zones = {
     "terraform-aws-modules-example.com" = {
@@ -40,7 +40,7 @@ module "zones" {
 
 module "records" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   zone_name = keys(module.zones.route53_zone_zone_id)[0]
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -84,6 +84,30 @@ module "records" {
       }
     },
     {
+      name           = "geoproximity-aws-region"
+      type           = "CNAME"
+      ttl            = 5
+      records        = ["us-east-1.test.example.com."]
+      set_identifier = "us-east-1-region"
+      geoproximity_routing_policy = {
+        aws_region = "us-east-1"
+        bias       = 0
+      }
+    },
+    {
+      name           = "geoproximity-coordinates"
+      type           = "CNAME"
+      ttl            = 5
+      records        = ["nyc.test.example.com."]
+      set_identifier = "nyc"
+      geoproximity_routing_policy = {
+        coordinates = {
+          latitude  = "40.7128"
+          longitude = "-74.0060"
+        }
+      }
+    },
+    {
       name = "cloudfront"
       type = "A"
       alias = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -102,8 +102,8 @@ module "records" {
       set_identifier = "nyc"
       geoproximity_routing_policy = {
         coordinates = {
-          latitude  = "40.7128"
-          longitude = "-74.0060"
+          latitude  = "40.71"
+          longitude = "-74.01"
         }
       }
     },

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.49"
+      version = ">= 5.37"
     }
   }
 }

--- a/modules/delegation-sets/README.md
+++ b/modules/delegation-sets/README.md
@@ -47,7 +47,7 @@ module "zones" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
 
 ## Providers

--- a/modules/delegation-sets/versions.tf
+++ b/modules/delegation-sets/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -31,14 +31,14 @@ records_jsonencoded = jsonencode([
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -72,4 +72,22 @@ resource "aws_route53_record" "this" {
       subdivision = lookup(each.value.geolocation_routing_policy, "subdivision", null)
     }
   }
+
+  dynamic "geoproximity_routing_policy" {
+    for_each = length(keys(lookup(each.value, "geoproximity_routing_policy", {}))) == 0 ? [] : [true]
+
+    content {
+      aws_region       = lookup(each.value.geoproximity_routing_policy, "aws_region", null)
+      bias             = lookup(each.value.geoproximity_routing_policy, "bias", null)
+      local_zone_group = lookup(each.value.geoproximity_routing_policy, "local_zone_group", null)
+      dynamic "coordinates" {
+        for_each = lookup(each.value.geoproximity_routing_policy, "coordinates", null) == null ? [] : [lookup(each.value.geoproximity_routing_policy, "coordinates", null)]
+
+        content {
+          latitude  = coordinates.value.latitude
+          longitude = coordinates.value.longitude
+        }
+      }
+    }
+  }
 }

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -80,6 +80,7 @@ resource "aws_route53_record" "this" {
       aws_region       = lookup(each.value.geoproximity_routing_policy, "aws_region", null)
       bias             = lookup(each.value.geoproximity_routing_policy, "bias", null)
       local_zone_group = lookup(each.value.geoproximity_routing_policy, "local_zone_group", null)
+
       dynamic "coordinates" {
         for_each = lookup(each.value.geoproximity_routing_policy, "coordinates", null) == null ? [] : [lookup(each.value.geoproximity_routing_policy, "coordinates", null)]
 

--- a/modules/records/versions.tf
+++ b/modules/records/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.49"
+      version = ">= 5.37"
     }
   }
 }

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -31,7 +31,7 @@ module "resolver_rule_associations" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
 
 ## Providers

--- a/modules/resolver-rule-associations/versions.tf
+++ b/modules/resolver-rule-associations/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -7,7 +7,7 @@ This module creates Route53 zones.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change extends the route53 records module by adding support for geoproximity routing policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

AWS recently added support for [geopriximity](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html) routing and this change will allow creation of records using that new policy. The module currently does not support it.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
