### PR TITLE
feat: Add resolver-endpoints submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ There are independent submodules:
 - [zones](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zones) - to manage Route53 zones
 - [records](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/records) - to manage Route53 records
 - [delegation-sets](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/delegation-sets) - to manage Route53 delegation sets
+- [resolver-endpoints](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/resolver-endpoints) - to manage Route53 resolver endpoints
 - [resolver-rule-associations](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/resolver-rule-associations) - to manage Route53 resolver rule associations
 
 ## Usage

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -37,6 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | terraform-aws-modules/cloudfront/aws | ~> 3.0 |
 | <a name="module_delegation_sets"></a> [delegation\_sets](#module\_delegation\_sets) | ../../modules/delegation-sets | n/a |
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
+| <a name="module_disabled_resolver_endpoints"></a> [disabled\_resolver\_endpoints](#module\_disabled\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
 | <a name="module_records_with_full_names"></a> [records\_with\_full\_names](#module\_records\_with\_full\_names) | ../../modules/records | n/a |
 | <a name="module_resolver_endpoints"></a> [resolver\_endpoints](#module\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
@@ -53,6 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_route53_health_check.failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_resolver_rule.sys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -39,6 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
 | <a name="module_records_with_full_names"></a> [records\_with\_full\_names](#module\_records\_with\_full\_names) | ../../modules/records | n/a |
+| <a name="module_resolver_endpoints"></a> [resolver\_endpoints](#module\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_resolver_rule_associations"></a> [resolver\_rule\_associations](#module\_resolver\_rule\_associations) | ../../modules/resolver-rule-associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_terragrunt"></a> [terragrunt](#module\_terragrunt) | ../../modules/records | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -258,6 +258,23 @@ module "resolver_rule_associations" {
   }
 }
 
+module "resolver_endpoints" {
+  source = "../../modules/resolver-endpoints"
+
+  name      = "example1"
+  direction = "INBOUND"
+  protocols = ["Do53", "DoH"]
+
+  subnet_ids = [
+    slice(module.vpc1.private_subnets, 0, 2)
+  ]
+
+  vpc_id = module.vpc1.vpc_id
+  security_group_ingress_cidr_blocks = [
+    module.vpc2.vpc_cidr_block
+  ]
+}
+
 module "disabled_records" {
   source = "../../modules/records"
 

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -1,0 +1,54 @@
+# Route53 Resolver Endpoints
+
+This module creates Route53 Resolver Endpoints.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_resolver_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_endpoint) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 resolver endpoints | `bool` | `true` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create Security Groups for Route53 Resolver Endpoints | `bool` | `true` | no |
+| <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | n/a | yes |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | n/a | yes |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `"Managed by Terraform."` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs | `list(string)` | `[]` | no |
+| <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group | `list(string)` | `[]` | no |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The security group name | `string` | `""` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | n/a | yes |
+| <a name="input_type"></a> [type](#input\_type) | The resolver endpoint IP type | `string` | `"IPV4"` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for all the Route53 Resolver Endpoints | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_route53_resolver_endpoint_arn"></a> [route53\_resolver\_endpoint\_arn](#output\_route53\_resolver\_endpoint\_arn) | The ARN of the Resolver Endpoint |
+| <a name="output_route53_resolver_endpoint_id"></a> [route53\_resolver\_endpoint\_id](#output\_route53\_resolver\_endpoint\_id) | The ID of the Resolver Endpoint |
+| <a name="output_route53_resolver_endpoint_ip_addresses"></a> [route53\_resolver\_endpoint\_ip\_addresses](#output\_route53\_resolver\_endpoint\_ip\_addresses) | Resolver Endpoint IP Addresses |
+| <a name="output_route53_resolver_endpoint_security_groups"></a> [route53\_resolver\_endpoint\_security\_groups](#output\_route53\_resolver\_endpoint\_security\_groups) | Security Group IDs mapped to Resolver Endpoint |
+| <a name="output_route53_resolver_endpoint_vpc_id"></a> [route53\_resolver\_endpoint\_vpc\_id](#output\_route53\_resolver\_endpoint\_vpc\_id) | The VPC ID used by the Resolver Endpoint |

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -2,18 +2,19 @@
 
 This module creates Route53 Resolver Endpoints.
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 
 ## Modules
 
@@ -33,13 +34,16 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 resolver endpoints | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create Security Groups for Route53 Resolver Endpoints | `bool` | `true` | no |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | n/a | yes |
-| <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | n/a | yes |
-| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `"Managed by Terraform."` | no |
+| <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | `null` | no |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | `[]` | no |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `null` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs | `list(string)` | `[]` | no |
 | <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group | `list(string)` | `[]` | no |
-| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The security group name | `string` | `""` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | n/a | yes |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The name of the security group | `string` | `null` | no |
+| <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
+| <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | A map of tags for the security group | `map(string)` | `{}` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags for the Route53 resolver endpoint | `map(string)` | `{}` | no |
 | <a name="input_type"></a> [type](#input\_type) | The resolver endpoint IP type | `string` | `"IPV4"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for all the Route53 Resolver Endpoints | `string` | `""` | no |
 
@@ -48,7 +52,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_route53_resolver_endpoint_arn"></a> [route53\_resolver\_endpoint\_arn](#output\_route53\_resolver\_endpoint\_arn) | The ARN of the Resolver Endpoint |
+| <a name="output_route53_resolver_endpoint_host_vpc_id"></a> [route53\_resolver\_endpoint\_host\_vpc\_id](#output\_route53\_resolver\_endpoint\_host\_vpc\_id) | The VPC ID used by the Resolver Endpoint |
 | <a name="output_route53_resolver_endpoint_id"></a> [route53\_resolver\_endpoint\_id](#output\_route53\_resolver\_endpoint\_id) | The ID of the Resolver Endpoint |
 | <a name="output_route53_resolver_endpoint_ip_addresses"></a> [route53\_resolver\_endpoint\_ip\_addresses](#output\_route53\_resolver\_endpoint\_ip\_addresses) | Resolver Endpoint IP Addresses |
-| <a name="output_route53_resolver_endpoint_security_groups"></a> [route53\_resolver\_endpoint\_security\_groups](#output\_route53\_resolver\_endpoint\_security\_groups) | Security Group IDs mapped to Resolver Endpoint |
-| <a name="output_route53_resolver_endpoint_vpc_id"></a> [route53\_resolver\_endpoint\_vpc\_id](#output\_route53\_resolver\_endpoint\_vpc\_id) | The VPC ID used by the Resolver Endpoint |
+| <a name="output_route53_resolver_endpoint_security_group_ids"></a> [route53\_resolver\_endpoint\_security\_group\_ids](#output\_route53\_resolver\_endpoint\_security\_group\_ids) | Security Group IDs mapped to Resolver Endpoint |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -1,0 +1,53 @@
+locals {
+  security_group_ids = var.create_security_group ? [aws_security_group.this[0].id] : var.security_group_ids
+}
+
+resource "aws_route53_resolver_endpoint" "this" {
+  count = var.create ? 1 : 0
+
+  name      = var.name
+  direction = var.direction
+
+  resolver_endpoint_type = var.type
+  security_group_ids     = local.security_group_ids
+
+  dynamic "ip_address" {
+    for_each = var.subnet_ids
+    content {
+      subnet_id = var.subnet_ids[ip_address.key]
+    }
+  }
+
+  protocols = var.protocols
+}
+
+resource "aws_security_group" "this" {
+  count = var.create && var.create_security_group ? 1 : 0
+
+  name        = var.name
+  description = var.security_group_description
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = toset(["tcp", "udp"])
+    content {
+      description = "Allow DNS"
+      protocol    = ingress.value
+      from_port   = 53
+      to_port     = 53
+      cidr_blocks = var.security_group_ingress_cidr_blocks
+    }
+  }
+
+  egress {
+    description = "Allow All"
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-sg"
+  }
+}

--- a/modules/resolver-endpoints/outputs.tf
+++ b/modules/resolver-endpoints/outputs.tf
@@ -1,25 +1,25 @@
 
 output "route53_resolver_endpoint_id" {
   description = "The ID of the Resolver Endpoint"
-  value       = aws_route53_resolver_endpoint.this[0].id
+  value       = try(aws_route53_resolver_endpoint.this[0].id, null)
 }
 
 output "route53_resolver_endpoint_arn" {
   description = "The ARN of the Resolver Endpoint"
-  value       = aws_route53_resolver_endpoint.this[0].arn
+  value       = try(aws_route53_resolver_endpoint.this[0].arn, null)
 }
 
-output "route53_resolver_endpoint_vpc_id" {
+output "route53_resolver_endpoint_host_vpc_id" {
   description = "The VPC ID used by the Resolver Endpoint"
-  value       = aws_route53_resolver_endpoint.this[0].host_vpc_id
+  value       = try(aws_route53_resolver_endpoint.this[0].host_vpc_id, null)
 }
 
-output "route53_resolver_endpoint_security_groups" {
+output "route53_resolver_endpoint_security_group_ids" {
   description = "Security Group IDs mapped to Resolver Endpoint"
-  value       = aws_route53_resolver_endpoint.this[0].security_group_ids
+  value       = try(aws_route53_resolver_endpoint.this[0].security_group_ids, null)
 }
 
 output "route53_resolver_endpoint_ip_addresses" {
   description = "Resolver Endpoint IP Addresses"
-  value       = aws_route53_resolver_endpoint.this[0].ip_address
+  value       = try(aws_route53_resolver_endpoint.this[0].ip_address, null)
 }

--- a/modules/resolver-endpoints/outputs.tf
+++ b/modules/resolver-endpoints/outputs.tf
@@ -1,0 +1,25 @@
+
+output "route53_resolver_endpoint_id" {
+  description = "The ID of the Resolver Endpoint"
+  value       = aws_route53_resolver_endpoint.this[0].id
+}
+
+output "route53_resolver_endpoint_arn" {
+  description = "The ARN of the Resolver Endpoint"
+  value       = aws_route53_resolver_endpoint.this[0].arn
+}
+
+output "route53_resolver_endpoint_vpc_id" {
+  description = "The VPC ID used by the Resolver Endpoint"
+  value       = aws_route53_resolver_endpoint.this[0].host_vpc_id
+}
+
+output "route53_resolver_endpoint_security_groups" {
+  description = "Security Group IDs mapped to Resolver Endpoint"
+  value       = aws_route53_resolver_endpoint.this[0].security_group_ids
+}
+
+output "route53_resolver_endpoint_ip_addresses" {
+  description = "Resolver Endpoint IP Addresses"
+  value       = aws_route53_resolver_endpoint.this[0].ip_address
+}

--- a/modules/resolver-endpoints/variables.tf
+++ b/modules/resolver-endpoints/variables.tf
@@ -7,52 +7,43 @@ variable "create" {
 variable "name" {
   description = "The resolver endpoint name"
   type        = string
+  default     = null
 }
 
 variable "protocols" {
   description = "The resolver endpoint protocols"
-  validation {
-    condition = alltrue([
-      for value in var.protocols : contains(["DoH", "Do53", "DoH-FIPS"], value)
-    ])
-    error_message = "Invalid value. Valid values are `DoH`, `Do53` and `DoH-FIPS`"
-  }
-  type = list(string)
+  type        = list(string)
+  default     = []
 }
 
 variable "direction" {
   description = "The resolver endpoint flow direction"
   type        = string
-  validation {
-    condition     = contains(["INBOUND", "OUTBOUND"], var.direction)
-    error_message = "Invalid value. Valid values are `INBOUND` and `OUTBOUND`"
-  }
-  default = "INBOUND"
+  default     = "INBOUND"
 }
 
 variable "type" {
   description = "The resolver endpoint IP type"
   type        = string
-  validation {
-    condition     = contains(["IPV4", "IPV6"], var.type)
-    error_message = "Invalid value. Valid values are `IPV4` or `IPV6`"
-  }
-  default = "IPV4"
+  default     = "IPV4"
 }
 
 variable "subnet_ids" {
   description = "A list of subnets where Route53 resolver endpoints will be deployed"
-  validation {
-    condition     = length(var.subnet_ids) >= 1
-    error_message = "Invalid value. We should have at least 1 subnet."
-  }
-  type = list(string)
+  type        = list(string)
+  default     = []
 }
 
 variable "security_group_ids" {
   description = "A list of security group IDs"
   type        = list(string)
   default     = []
+}
+
+variable "tags" {
+  description = "A map of tags for the Route53 resolver endpoint"
+  type        = map(string)
+  default     = {}
 }
 
 # Security Group
@@ -69,14 +60,32 @@ variable "vpc_id" {
   default     = ""
 }
 
+variable "security_group_name" {
+  description = "The name of the security group"
+  type        = string
+  default     = null
+}
+
+variable "security_group_name_prefix" {
+  description = "The prefix of the security group"
+  type        = string
+  default     = null
+}
+
 variable "security_group_description" {
   description = "The security group description"
   type        = string
-  default     = "Managed by Terraform."
+  default     = null
 }
 
 variable "security_group_ingress_cidr_blocks" {
   description = "A list of CIDR blocks to allow on security group"
   type        = list(string)
   default     = []
+}
+
+variable "security_group_tags" {
+  description = "A map of tags for the security group"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/resolver-endpoints/variables.tf
+++ b/modules/resolver-endpoints/variables.tf
@@ -1,0 +1,82 @@
+variable "create" {
+  description = "Whether to create Route53 resolver endpoints"
+  type        = bool
+  default     = true
+}
+
+variable "name" {
+  description = "The resolver endpoint name"
+  type        = string
+}
+
+variable "protocols" {
+  description = "The resolver endpoint protocols"
+  validation {
+    condition = alltrue([
+      for value in var.protocols : contains(["DoH", "Do53", "DoH-FIPS"], value)
+    ])
+    error_message = "Invalid value. Valid values are `DoH`, `Do53` and `DoH-FIPS`"
+  }
+  type = list(string)
+}
+
+variable "direction" {
+  description = "The resolver endpoint flow direction"
+  type        = string
+  validation {
+    condition     = contains(["INBOUND", "OUTBOUND"], var.direction)
+    error_message = "Invalid value. Valid values are `INBOUND` and `OUTBOUND`"
+  }
+  default = "INBOUND"
+}
+
+variable "type" {
+  description = "The resolver endpoint IP type"
+  type        = string
+  validation {
+    condition     = contains(["IPV4", "IPV6"], var.type)
+    error_message = "Invalid value. Valid values are `IPV4` or `IPV6`"
+  }
+  default = "IPV4"
+}
+
+variable "subnet_ids" {
+  description = "A list of subnets where Route53 resolver endpoints will be deployed"
+  validation {
+    condition     = length(var.subnet_ids) >= 1
+    error_message = "Invalid value. We should have at least 1 subnet."
+  }
+  type = list(string)
+}
+
+variable "security_group_ids" {
+  description = "A list of security group IDs"
+  type        = list(string)
+  default     = []
+}
+
+# Security Group
+
+variable "create_security_group" {
+  description = "Whether to create Security Groups for Route53 Resolver Endpoints"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "The VPC ID for all the Route53 Resolver Endpoints"
+  type        = string
+  default     = ""
+}
+
+variable "security_group_description" {
+  description = "The security group description"
+  type        = string
+  default     = "Managed by Terraform."
+}
+
+variable "security_group_ingress_cidr_blocks" {
+  description = "A list of CIDR blocks to allow on security group"
+  type        = list(string)
+  default     = []
+}

--- a/modules/resolver-endpoints/versions.tf
+++ b/modules/resolver-endpoints/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.56"
+    }
+  }
+}

--- a/modules/resolver-endpoints/versions.tf
+++ b/modules/resolver-endpoints/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 5.32"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR add a new submodule to create Route53 Resolver Endpoints

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Through Resolver endpoints and conditional forwarding rules, you can resolve DNS queries between your on-premises resources and VPCs to create a hybrid cloud setup over VPN or Direct Connect (DX). Specifically:
- Inbound Resolver endpoints allow DNS queries to your VPC from your on-premises network or another VPC.
- Outbound Resolver endpoints allow DNS queries from your VPC to your on-premises network or another VPC.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
