### PR TITLE
fix: Add egress rule update support

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -38,9 +38,10 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_delegation_sets"></a> [delegation\_sets](#module\_delegation\_sets) | ../../modules/delegation-sets | n/a |
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
 | <a name="module_disabled_resolver_endpoints"></a> [disabled\_resolver\_endpoints](#module\_disabled\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
+| <a name="module_inbound_resolver_endpoints"></a> [inbound\_resolver\_endpoints](#module\_inbound\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
+| <a name="module_outbound_resolver_endpoints"></a> [outbound\_resolver\_endpoints](#module\_outbound\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
 | <a name="module_records_with_full_names"></a> [records\_with\_full\_names](#module\_records\_with\_full\_names) | ../../modules/records | n/a |
-| <a name="module_resolver_endpoints"></a> [resolver\_endpoints](#module\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_resolver_rule_associations"></a> [resolver\_rule\_associations](#module\_resolver\_rule\_associations) | ../../modules/resolver-rule-associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_terragrunt"></a> [terragrunt](#module\_terragrunt) | ../../modules/records | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -300,14 +300,7 @@ module "inbound_resolver_endpoints" {
   direction = "INBOUND"
   protocols = ["Do53", "DoH"]
 
-  ip_address = [
-    {
-      subnet_id = module.vpc1.private_subnets[0]
-    },
-    {
-      subnet_id = module.vpc1.private_subnets[1]
-    }
-  ]
+  subnet_ids = slice(module.vpc1.private_subnets, 0, 2)
 
   vpc_id                     = module.vpc1.vpc_id
   security_group_name_prefix = "example1-sg-"
@@ -326,11 +319,14 @@ module "outbound_resolver_endpoints" {
   direction = "OUTBOUND"
   protocols = ["Do53", "DoH"]
 
+  # Using fixed IP addresses
   ip_address = [
     {
+      ip        = "10.0.0.35"
       subnet_id = module.vpc1.private_subnets[0]
     },
     {
+      ip        = "10.0.1.35"
       subnet_id = module.vpc1.private_subnets[1]
     }
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -288,10 +288,18 @@ module "resolver_rule_associations" {
 module "inbound_resolver_endpoints" {
   source = "../../modules/resolver-endpoints"
 
-  name       = "example1"
-  direction  = "INBOUND"
-  protocols  = ["Do53", "DoH"]
-  subnet_ids = module.vpc1.private_subnets
+  name      = "example1"
+  direction = "INBOUND"
+  protocols = ["Do53", "DoH"]
+
+  ip_address = [
+    {
+      subnet_id = module.vpc1.private_subnets[0]
+    },
+    {
+      subnet_id = module.vpc1.private_subnets[1]
+    }
+  ]
 
   vpc_id                     = module.vpc1.vpc_id
   security_group_name_prefix = "example1-sg-"
@@ -306,10 +314,18 @@ module "inbound_resolver_endpoints" {
 module "outbound_resolver_endpoints" {
   source = "../../modules/resolver-endpoints"
 
-  name       = "example2"
-  direction  = "OUTBOUND"
-  protocols  = ["Do53", "DoH"]
-  subnet_ids = module.vpc1.private_subnets
+  name      = "example2"
+  direction = "OUTBOUND"
+  protocols = ["Do53", "DoH"]
+
+  ip_address = [
+    {
+      subnet_id = module.vpc1.private_subnets[0]
+    },
+    {
+      subnet_id = module.vpc1.private_subnets[1]
+    }
+  ]
 
   vpc_id                     = module.vpc1.vpc_id
   security_group_name_prefix = "example2-sg-"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -285,7 +285,7 @@ module "resolver_rule_associations" {
   }
 }
 
-module "resolver_endpoints" {
+module "inbound_resolver_endpoints" {
   source = "../../modules/resolver-endpoints"
 
   name       = "example1"
@@ -296,6 +296,27 @@ module "resolver_endpoints" {
   vpc_id                     = module.vpc1.vpc_id
   security_group_name_prefix = "example1-sg-"
   security_group_ingress_cidr_blocks = [
+    module.vpc2.vpc_cidr_block
+  ]
+  security_group_egress_cidr_blocks = [
+    module.vpc2.vpc_cidr_block
+  ]
+}
+
+module "outbound_resolver_endpoints" {
+  source = "../../modules/resolver-endpoints"
+
+  name       = "example2"
+  direction  = "OUTBOUND"
+  protocols  = ["Do53", "DoH"]
+  subnet_ids = module.vpc1.private_subnets
+
+  vpc_id                     = module.vpc1.vpc_id
+  security_group_name_prefix = "example2-sg-"
+  security_group_ingress_cidr_blocks = [
+    module.vpc1.vpc_cidr_block
+  ]
+  security_group_egress_cidr_blocks = [
     module.vpc2.vpc_cidr_block
   ]
 }

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -37,8 +37,9 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | `null` | no |
 | <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | `[]` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `null` | no |
+| <a name="input_security_group_egress_cidr_blocks"></a> [security\_group\_egress\_cidr\_blocks](#input\_security\_group\_egress\_cidr\_blocks) | A list of CIDR blocks to allow on security group egress rules | `list(string)` | `[]` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs | `list(string)` | `[]` | no |
-| <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group | `list(string)` | `[]` | no |
+| <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group ingress rules | `list(string)` | `[]` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The name of the security group | `string` | `null` | no |
 | <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | A map of tags for the security group | `map(string)` | `{}` | no |

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 resolver endpoints | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create Security Groups for Route53 Resolver Endpoints | `bool` | `true` | no |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
+| <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | <pre>list(object({<br>    ip        = optional(string)<br>    subnet_id = string<br>  }))</pre> | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | `null` | no |
 | <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | `[]` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `null` | no |
@@ -43,7 +44,6 @@ No modules.
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The name of the security group | `string` | `null` | no |
 | <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | A map of tags for the security group | `map(string)` | `{}` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags for the Route53 resolver endpoint | `map(string)` | `{}` | no |
 | <a name="input_type"></a> [type](#input\_type) | The resolver endpoint IP type | `string` | `"IPV4"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for all the Route53 Resolver Endpoints | `string` | `""` | no |

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -34,7 +34,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 resolver endpoints | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create Security Groups for Route53 Resolver Endpoints | `bool` | `true` | no |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
-| <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | <pre>list(object({<br>    ip        = optional(string)<br>    subnet_id = string<br>  }))</pre> | `[]` | no |
+| <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | `list(any)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | `null` | no |
 | <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | `[]` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The security group description | `string` | `null` | no |
@@ -44,6 +44,7 @@ No modules.
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The name of the security group | `string` | `null` | no |
 | <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | A map of tags for the security group | `map(string)` | `{}` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(any)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags for the Route53 resolver endpoint | `map(string)` | `{}` | no |
 | <a name="input_type"></a> [type](#input\_type) | The resolver endpoint IP type | `string` | `"IPV4"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for all the Route53 Resolver Endpoints | `string` | `""` | no |

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -44,12 +44,16 @@ resource "aws_security_group" "this" {
     }
   }
 
-  egress {
-    description = "Allow All"
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
+  dynamic "egress" {
+    for_each = toset(["tcp", "udp"])
+
+    content {
+      description = "Allow DNS"
+      protocol    = egress.value
+      from_port   = 53
+      to_port     = 53
+      cidr_blocks = var.security_group_egress_cidr_blocks
+    }
   }
 
   tags = var.security_group_tags

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -1,5 +1,6 @@
 locals {
   security_group_ids = var.create && var.create_security_group ? [aws_security_group.this[0].id] : var.security_group_ids
+  subnet_ids         = var.create && length(var.subnet_ids) > 0 ? [for subnet in var.subnet_ids : { subnet_id = subnet }] : var.subnet_ids
 }
 
 resource "aws_route53_resolver_endpoint" "this" {
@@ -12,11 +13,11 @@ resource "aws_route53_resolver_endpoint" "this" {
   security_group_ids     = local.security_group_ids
 
   dynamic "ip_address" {
-    for_each = var.ip_address
+    for_each = length(var.ip_address) == 0 ? local.subnet_ids : var.ip_address
 
     content {
       ip        = lookup(ip_address.value, "ip", null)
-      subnet_id = ip_address.value.subnet_id
+      subnet_id = each.value.subnet_id
     }
   }
 

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -54,7 +54,7 @@ resource "aws_security_group" "this" {
       protocol    = egress.value
       from_port   = 53
       to_port     = 53
-      cidr_blocks = var.security_group_egress_cidr_blocks
+      cidr_blocks = try(var.security_group_egress_cidr_blocks, ["0.0.0.0"])
     }
   }
 

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -12,10 +12,11 @@ resource "aws_route53_resolver_endpoint" "this" {
   security_group_ids     = local.security_group_ids
 
   dynamic "ip_address" {
-    for_each = var.subnet_ids
+    for_each = var.ip_address
 
     content {
-      subnet_id = ip_address.value
+      ip        = ip_address.value.ip
+      subnet_id = ip_address.value.subnet_id
     }
   }
 

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -15,7 +15,7 @@ resource "aws_route53_resolver_endpoint" "this" {
     for_each = var.ip_address
 
     content {
-      ip        = ip_address.value.ip
+      ip        = lookup(ip_address.value, "ip", null)
       subnet_id = ip_address.value.subnet_id
     }
   }

--- a/modules/resolver-endpoints/variables.tf
+++ b/modules/resolver-endpoints/variables.tf
@@ -79,7 +79,13 @@ variable "security_group_description" {
 }
 
 variable "security_group_ingress_cidr_blocks" {
-  description = "A list of CIDR blocks to allow on security group"
+  description = "A list of CIDR blocks to allow on security group ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_egress_cidr_blocks" {
+  description = "A list of CIDR blocks to allow on security group egress rules"
   type        = list(string)
   default     = []
 }

--- a/modules/resolver-endpoints/variables.tf
+++ b/modules/resolver-endpoints/variables.tf
@@ -28,10 +28,13 @@ variable "type" {
   default     = "IPV4"
 }
 
-variable "subnet_ids" {
-  description = "A list of subnets where Route53 resolver endpoints will be deployed"
-  type        = list(string)
-  default     = []
+variable "ip_address" {
+  description = "A list of IP addresses and subnets where Route53 resolver endpoints will be deployed"
+  type = list(object({
+    ip        = optional(string)
+    subnet_id = string
+  }))
+  default = []
 }
 
 variable "security_group_ids" {

--- a/modules/resolver-endpoints/variables.tf
+++ b/modules/resolver-endpoints/variables.tf
@@ -28,13 +28,16 @@ variable "type" {
   default     = "IPV4"
 }
 
+variable "subnet_ids" {
+  description = "A list of subnets where Route53 resolver endpoints will be deployed"
+  type        = list(any)
+  default     = []
+}
+
 variable "ip_address" {
   description = "A list of IP addresses and subnets where Route53 resolver endpoints will be deployed"
-  type = list(object({
-    ip        = optional(string)
-    subnet_id = string
-  }))
-  default = []
+  type        = list(any)
+  default     = []
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR complements https://github.com/terraform-aws-modules/terraform-aws-route53/pull/106 by adding a new variable, allowing the submodule to update egress rules. This PR also adds support for setting static IP address on the resolver endpoint instances.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous pull request was hardcoding an egress rule allowing All the traffic. Users could want to update these rules as their needs.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
