### PR TITLE
feat!: Add primary name server to outputs in modules/zones. Bump AWS provider version to 4

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -61,6 +61,14 @@ module "records" {
   records = [
     {
       name = ""
+      type = "SOA"
+      ttl  = 900
+      records = [
+        "${module.zones.primary_name_server[local.zone_name]}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60",
+      ]
+    },
+    {
+      name = ""
       type = "A"
       ttl  = 3600
       records = [

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -8,13 +8,13 @@ This module creates Route53 zones.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.36.0 |
 
 ## Modules
 

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -38,6 +38,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_primary_name_server"></a> [primary\_name\_server](#output\_primary\_name\_server) | The Route 53 name server that created the SOA record. |
 | <a name="output_route53_static_zone_name"></a> [route53\_static\_zone\_name](#output\_route53\_static\_zone\_name) | Name of Route53 zone created statically to avoid invalid count argument error when creating records and zones simmultaneously |
 | <a name="output_route53_zone_name"></a> [route53\_zone\_name](#output\_route53\_zone\_name) | Name of Route53 zone |
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -13,6 +13,11 @@ output "route53_zone_name_servers" {
   value       = { for k, v in aws_route53_zone.this : k => v.name_servers }
 }
 
+output "primary_name_server" {
+  description = "The Route 53 name server that created the SOA record."
+  value       = { for k, v in aws_route53_zone.this : k => v.primary_name_server }
+}
+
 output "route53_zone_name" {
   description = "Name of Route53 zone"
   value       = { for k, v in aws_route53_zone.this : k => v.name }

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.49"
+      version = ">= 4.36.0"
     }
   }
 }


### PR DESCRIPTION
## Description
One more output has been added in zones module in this PR: `primary_name_server`.

## Motivation and Context
This new output could be useful if SOA record modification is required in dependent modules.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
