### PR TITLE
feat: Add zone-cross-account-vpc-association submodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.91.0
+    rev: v1.94.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ There are independent submodules:
 - [delegation-sets](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/delegation-sets) - to manage Route53 delegation sets
 - [resolver-endpoints](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/resolver-endpoints) - to manage Route53 resolver endpoints
 - [resolver-rule-associations](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/resolver-rule-associations) - to manage Route53 resolver rule associations
+- [zone-cross-account-vpc-association](https://github.com/terraform-aws-modules/terraform-aws-route53/tree/master/modules/zone-cross-account-vpc-association) - to associate Route53 zones with VPCs from different AWS accounts
 
 ## Usage
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -82,4 +82,4 @@ No inputs.
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
 | <a name="output_route53_zone_zone_arn"></a> [route53\_zone\_zone\_arn](#output\_route53\_zone\_zone\_arn) | Zone ARN of Route53 zone |
 | <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,6 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
+| <a name="provider_aws.second_account"></a> [aws.second\_account](#provider\_aws.second\_account) | >= 5.37 |
 
 ## Modules
 
@@ -38,6 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_delegation_sets"></a> [delegation\_sets](#module\_delegation\_sets) | ../../modules/delegation-sets | n/a |
 | <a name="module_disabled_records"></a> [disabled\_records](#module\_disabled\_records) | ../../modules/records | n/a |
 | <a name="module_disabled_resolver_endpoints"></a> [disabled\_resolver\_endpoints](#module\_disabled\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
+| <a name="module_disabled_zone_cross_account_vpc_association"></a> [disabled\_zone\_cross\_account\_vpc\_association](#module\_disabled\_zone\_cross\_account\_vpc\_association) | ../../modules/zone-cross-account-vpc-association | n/a |
 | <a name="module_inbound_resolver_endpoints"></a> [inbound\_resolver\_endpoints](#module\_inbound\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_outbound_resolver_endpoints"></a> [outbound\_resolver\_endpoints](#module\_outbound\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
@@ -47,6 +49,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_terragrunt"></a> [terragrunt](#module\_terragrunt) | ../../modules/records | n/a |
 | <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc_otheraccount"></a> [vpc\_otheraccount](#module\_vpc\_otheraccount) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_zone_cross_account_vpc_association"></a> [zone\_cross\_account\_vpc\_association](#module\_zone\_cross\_account\_vpc\_association) | ../../modules/zone-cross-account-vpc-association | n/a |
 | <a name="module_zones"></a> [zones](#module\_zones) | ../../modules/zones | n/a |
 
 ## Resources
@@ -56,6 +60,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_route53_health_check.failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_resolver_rule.sys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_region.second_account_current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/modules/delegation-sets/README.md
+++ b/modules/delegation-sets/README.md
@@ -42,7 +42,7 @@ module "zones" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -80,4 +80,4 @@ No modules.
 | <a name="output_route53_delegation_set_id"></a> [route53\_delegation\_set\_id](#output\_route53\_delegation\_set\_id) | ID of Route53 delegation set |
 | <a name="output_route53_delegation_set_name_servers"></a> [route53\_delegation\_set\_name\_servers](#output\_route53\_delegation\_set\_name\_servers) | Name servers in the Route53 delegation set |
 | <a name="output_route53_delegation_set_reference_name"></a> [route53\_delegation\_set\_reference\_name](#output\_route53\_delegation\_set\_reference\_name) | Reference name used when the Route53 delegation set has been created |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/delegation-sets/main.tf
+++ b/modules/delegation-sets/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_delegation_set" "this" {
-  for_each = var.create ? var.delegation_sets : tomap({})
+  for_each = { for k, v in var.delegation_sets : k => v if var.create }
 
   reference_name = lookup(each.value, "reference_name", null)
 }

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -26,7 +26,7 @@ records_jsonencoded = jsonencode([
 ])
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -68,4 +68,4 @@ No modules.
 |------|-------------|
 | <a name="output_route53_record_fqdn"></a> [route53\_record\_fqdn](#output\_route53\_record\_fqdn) | FQDN built using the zone domain and name |
 | <a name="output_route53_record_name"></a> [route53\_record\_name](#output\_route53\_record\_name) | The name of the record |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -2,7 +2,7 @@
 
 This module creates Route53 Resolver Endpoints.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -58,4 +58,4 @@ No modules.
 | <a name="output_route53_resolver_endpoint_id"></a> [route53\_resolver\_endpoint\_id](#output\_route53\_resolver\_endpoint\_id) | The ID of the Resolver Endpoint |
 | <a name="output_route53_resolver_endpoint_ip_addresses"></a> [route53\_resolver\_endpoint\_ip\_addresses](#output\_route53\_resolver\_endpoint\_ip\_addresses) | Resolver Endpoint IP Addresses |
 | <a name="output_route53_resolver_endpoint_security_group_ids"></a> [route53\_resolver\_endpoint\_security\_group\_ids](#output\_route53\_resolver\_endpoint\_security\_group\_ids) | Security Group IDs mapped to Resolver Endpoint |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/resolver-endpoints/main.tf
+++ b/modules/resolver-endpoints/main.tf
@@ -1,6 +1,6 @@
 locals {
   security_group_ids = var.create && var.create_security_group ? [aws_security_group.this[0].id] : var.security_group_ids
-  subnet_ids         = var.create && length(var.subnet_ids) > 0 ? [for subnet in var.subnet_ids : { subnet_id = subnet }] : var.subnet_ids
+  subnet_ids         = [for subnet in var.subnet_ids : { subnet_id = subnet } if var.create]
 }
 
 resource "aws_route53_resolver_endpoint" "this" {
@@ -17,7 +17,7 @@ resource "aws_route53_resolver_endpoint" "this" {
 
     content {
       ip        = lookup(ip_address.value, "ip", null)
-      subnet_id = each.value.subnet_id
+      subnet_id = ip_address.value.subnet_id
     }
   }
 

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -26,7 +26,7 @@ module "resolver_rule_associations" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -65,4 +65,4 @@ No modules.
 | <a name="output_route53_resolver_rule_association_id"></a> [route53\_resolver\_rule\_association\_id](#output\_route53\_resolver\_rule\_association\_id) | ID of Route53 Resolver rule associations |
 | <a name="output_route53_resolver_rule_association_name"></a> [route53\_resolver\_rule\_association\_name](#output\_route53\_resolver\_rule\_association\_name) | Name of Route53 Resolver rule associations |
 | <a name="output_route53_resolver_rule_association_resolver_rule_id"></a> [route53\_resolver\_rule\_association\_resolver\_rule\_id](#output\_route53\_resolver\_rule\_association\_resolver\_rule\_id) | ID of Route53 Resolver rule associations resolver rule |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/zone-cross-account-vpc-association/README.md
+++ b/modules/zone-cross-account-vpc-association/README.md
@@ -35,7 +35,7 @@ module "zone_cross_account_vpc_association" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -75,4 +75,4 @@ No modules.
 | <a name="output_aws_route53_vpc_association_authorization_id"></a> [aws\_route53\_vpc\_association\_authorization\_id](#output\_aws\_route53\_vpc\_association\_authorization\_id) | ID of Route53 VPC association authorizations |
 | <a name="output_aws_route53_zone_association_id"></a> [aws\_route53\_zone\_association\_id](#output\_aws\_route53\_zone\_association\_id) | ID of Route53 VPC association |
 | <a name="output_aws_route53_zone_association_owning_account"></a> [aws\_route53\_zone\_association\_owning\_account](#output\_aws\_route53\_zone\_association\_owning\_account) | The account ID of the account that created the hosted zone. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/zone-cross-account-vpc-association/README.md
+++ b/modules/zone-cross-account-vpc-association/README.md
@@ -1,0 +1,78 @@
+# Route53 Zone cross-account VPC association
+
+This module creates cross-account Route53 Zone associations.
+
+It does need two providers to be passed to handle both AWS accounts:
+- `aws.r53_owner`: Account owning the Route53 zones to make the cross-account association authorization
+- `aws.vpc_owner`: Account owning the VPCs to associate with the Route53 zones
+
+Many-to-many associations are possible, using the zone_vpc_associations input variable.
+
+## Usage
+
+### Create Route53 Zone cross-account VPC association
+
+```hcl
+module "zone_cross_account_vpc_association" {
+  source = "terraform-aws-modules/route53/aws//modules/zone-cross-account-vpc-association"
+  version = "~> 3.2"
+  providers = {
+    aws.r53_owner = aws
+    aws.vpc_owner = aws.second_account
+  }
+
+  zone_vpc_associations = {
+    example = {
+      zone_id = "Z111111QQQQQQQ"
+      vpc_id  = "vpc-185a3e2f2d6d2c863"
+    },
+    example2 = {
+      zone_id    = "Z222222VVVVVVV"
+      vpc_id     = "vpc-123456789abcd1234"
+      vpc_region = "us-east-2"
+    },
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.r53_owner"></a> [aws.r53\_owner](#provider\_aws.r53\_owner) | >= 3.56 |
+| <a name="provider_aws.vpc_owner"></a> [aws.vpc\_owner](#provider\_aws.vpc\_owner) | >= 3.56 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_vpc_association_authorization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_vpc_association_authorization) | resource |
+| [aws_route53_zone_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Route53 Zone associations | `bool` | `true` | no |
+| <a name="input_zone_vpc_associations"></a> [zone\_vpc\_associations](#input\_zone\_vpc\_associations) | Map of associations indicating zone\_id and vpc\_id to associate. | <pre>map(object({<br>    zone_id    = string<br>    vpc_id     = string<br>    vpc_region = optional(string)<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_route53_vpc_association_authorization_id"></a> [aws\_route53\_vpc\_association\_authorization\_id](#output\_aws\_route53\_vpc\_association\_authorization\_id) | ID of Route53 VPC association authorizations |
+| <a name="output_aws_route53_zone_association_id"></a> [aws\_route53\_zone\_association\_id](#output\_aws\_route53\_zone\_association\_id) | ID of Route53 VPC association |
+| <a name="output_aws_route53_zone_association_owning_account"></a> [aws\_route53\_zone\_association\_owning\_account](#output\_aws\_route53\_zone\_association\_owning\_account) | The account ID of the account that created the hosted zone. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zone-cross-account-vpc-association/README.md
+++ b/modules/zone-cross-account-vpc-association/README.md
@@ -15,7 +15,7 @@ Many-to-many associations are possible, using the zone_vpc_associations input va
 ```hcl
 module "zone_cross_account_vpc_association" {
   source = "terraform-aws-modules/route53/aws//modules/zone-cross-account-vpc-association"
-  version = "~> 3.2"
+
   providers = {
     aws.r53_owner = aws
     aws.vpc_owner = aws.second_account

--- a/modules/zone-cross-account-vpc-association/main.tf
+++ b/modules/zone-cross-account-vpc-association/main.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_vpc_association_authorization" "this" {
+  for_each = { for k, v in var.zone_vpc_associations : k => v if var.create }
+
+  provider = aws.r53_owner
+
+  zone_id    = each.value.zone_id
+  vpc_id     = each.value.vpc_id
+  vpc_region = try(each.value.vpc_region, null)
+}
+
+resource "aws_route53_zone_association" "this" {
+  for_each = aws_route53_vpc_association_authorization.this
+
+  provider = aws.vpc_owner
+
+  vpc_id     = each.value.vpc_id
+  zone_id    = each.value.zone_id
+  vpc_region = try(each.value.vpc_region, null)
+}

--- a/modules/zone-cross-account-vpc-association/outputs.tf
+++ b/modules/zone-cross-account-vpc-association/outputs.tf
@@ -1,0 +1,14 @@
+output "aws_route53_vpc_association_authorization_id" {
+  description = "ID of Route53 VPC association authorizations"
+  value       = { for k, v in aws_route53_vpc_association_authorization.this : k => v.id }
+}
+
+output "aws_route53_zone_association_id" {
+  description = "ID of Route53 VPC association"
+  value       = { for k, v in aws_route53_zone_association.this : k => v.id }
+}
+
+output "aws_route53_zone_association_owning_account" {
+  description = "The account ID of the account that created the hosted zone."
+  value       = { for k, v in aws_route53_zone_association.this : k => v.owning_account }
+}

--- a/modules/zone-cross-account-vpc-association/variables.tf
+++ b/modules/zone-cross-account-vpc-association/variables.tf
@@ -1,0 +1,15 @@
+variable "create" {
+  description = "Whether to create Route53 Zone associations"
+  type        = bool
+  default     = true
+}
+
+variable "zone_vpc_associations" {
+  description = "Map of associations indicating zone_id and vpc_id to associate."
+  type = map(object({
+    zone_id    = string
+    vpc_id     = string
+    vpc_region = optional(string)
+  }))
+  default = {}
+}

--- a/modules/zone-cross-account-vpc-association/versions.tf
+++ b/modules/zone-cross-account-vpc-association/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.3.2"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 3.56"
+      configuration_aliases = [aws.r53_owner, aws.vpc_owner]
+    }
+  }
+}
+
+provider "aws" {
+  alias = "r53_owner"
+}
+
+provider "aws" {
+  alias = "vpc_owner"
+}

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -2,7 +2,7 @@
 
 This module creates Route53 zones.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -44,4 +44,4 @@ No modules.
 | <a name="output_route53_zone_name_servers"></a> [route53\_zone\_name\_servers](#output\_route53\_zone\_name\_servers) | Name servers of Route53 zone |
 | <a name="output_route53_zone_zone_arn"></a> [route53\_zone\_zone\_arn](#output\_route53\_zone\_zone\_arn) | Zone ARN of Route53 zone |
 | <a name="output_route53_zone_zone_id"></a> [route53\_zone\_zone\_id](#output\_route53\_zone\_zone\_id) | Zone ID of Route53 zone |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Description
This PR add a new submodule to create cross-account Route53 VPC associations, using the authorization association resources (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-associate-vpcs-different-accounts.html)

## Motivation and Context
For cross-account AWS documentation generally recommends using Route53Resolver. The API endpoint [CreateVPCAssociationAuthorization](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateVPCAssociationAuthorization.html) is not even implemented in AWS Console.

However, this option is simpler as it does not require explicit resolver infrastructure (living within the VPC with specific Elastic Network Interfaces) and it does not involve cost on paying the Route53Resolver infrastructure, which makes it ideal for (most) cases.

## Breaking Changes
N/A

## How Has This Been Tested?
* [x]  I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
* [x]  I have tested and validated these changes using one or more of the provided `examples/*` projects

* [x]  I have executed `pre-commit run -a` on my pull request
>