### PR TITLE
feat: Complex variable types for module zones

### DIFF
--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,23 +1,23 @@
 resource "aws_route53_zone" "this" {
   for_each = { for k, v in var.zones : k => v if var.create }
 
-  name          = lookup(each.value, "domain_name", each.key)
-  comment       = lookup(each.value, "comment", null)
-  force_destroy = lookup(each.value, "force_destroy", false)
+  name          = coalesce(each.value.domain_name, each.key)
+  comment       = each.value.comment
+  force_destroy = each.value.force_destroy
 
-  delegation_set_id = lookup(each.value, "delegation_set_id", null)
+  delegation_set_id = each.value.delegation_set_id
 
   dynamic "vpc" {
-    for_each = try(tolist(lookup(each.value, "vpc", [])), [lookup(each.value, "vpc", {})])
+    for_each = each.value.vpc
 
     content {
       vpc_id     = vpc.value.vpc_id
-      vpc_region = lookup(vpc.value, "vpc_region", null)
+      vpc_region = vpc.value.vpc_region
     }
   }
 
   tags = merge(
-    lookup(each.value, "tags", {}),
+    each.value.tags,
     var.tags
   )
 }

--- a/modules/zones/variables.tf
+++ b/modules/zones/variables.tf
@@ -6,12 +6,22 @@ variable "create" {
 
 variable "zones" {
   description = "Map of Route53 zone parameters"
-  type        = any
-  default     = {}
+  type = map(object({
+    domain_name       = optional(string)
+    comment           = optional(string)
+    force_destroy     = optional(bool)
+    delegation_set_id = optional(string)
+    vpc = optional(list(object({
+      vpc_id     = string
+      vpc_region = optional(string)
+    })))
+    tags = optional(map(string), {})
+  }))
+  default = {}
 }
 
 variable "tags" {
   description = "Tags added to all zones. Will take precedence over tags from the 'zones' variable"
-  type        = map(any)
+  type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
use descriptive variable types.

`versions.tf` already specifies higher than 1.3.0 so no change needed there.