### PR TITLE
feat!: Support timeouts, `cidr_routing_policy`, MSV of AWS provider v5

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
-| <a name="provider_aws.second_account"></a> [aws.second\_account](#provider\_aws.second\_account) | >= 5.37 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
+| <a name="provider_aws.second_account"></a> [aws.second\_account](#provider\_aws.second\_account) | >= 5.91 |
 
 ## Modules
 
@@ -57,6 +57,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_route53_cidr_collection.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_cidr_collection) | resource |
 | [aws_route53_health_check.failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_resolver_rule.sys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -28,6 +28,11 @@ module "zones" {
       tags = {
         Name = "terraform-aws-modules-example.com"
       }
+      timeouts = {
+        create = "2h"
+        update = "3h"
+        delete = "1h"
+      }
     }
 
     "app.terraform-aws-modules-example.com" = {
@@ -91,6 +96,11 @@ module "records" {
       records = [
         "${module.zones.primary_name_server[local.zone_name]}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60",
       ]
+      timeouts = {
+        create = "2h"
+        update = "2h"
+        delete = "1h"
+      }
     },
     {
       name = ""
@@ -99,6 +109,11 @@ module "records" {
       records = [
         "10.10.10.10",
       ]
+      set_identifier = "dev"
+      cidr_routing_policy = {
+        collection_id = aws_route53_cidr_collection.example.id
+        location_name = "*"
+      }
     },
     {
       key  = "s3-bucket"
@@ -513,4 +528,8 @@ module "vpc_otheraccount" {
 resource "aws_route53_resolver_rule" "sys" {
   domain_name = "sys-example.com"
   rule_type   = "SYSTEM"
+}
+
+resource "aws_route53_cidr_collection" "example" {
+  name = "collection-1"
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.37"
+      version = ">= 5.91"
     }
   }
 }

--- a/modules/delegation-sets/README.md
+++ b/modules/delegation-sets/README.md
@@ -48,13 +48,13 @@ module "zones" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
 
 ## Modules
 

--- a/modules/delegation-sets/versions.tf
+++ b/modules/delegation-sets/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 5.91"
     }
   }
 }

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -32,13 +32,13 @@ records_jsonencoded = jsonencode([
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
 
 ## Modules
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -91,4 +91,23 @@ resource "aws_route53_record" "this" {
       }
     }
   }
+
+  dynamic "cidr_routing_policy" {
+    for_each = try([each.value.cidr_routing_policy], [])
+
+    content {
+      collection_id = cidr_routing_policy.value.collection_id
+      location_name = cidr_routing_policy.value.location_name
+    }
+  }
+
+  dynamic "timeouts" {
+    for_each = try([each.value.timeouts], [])
+
+    content {
+      create = try(timeouts.value.create, null)
+      update = try(timeouts.value.update, null)
+      delete = try(timeouts.value.delete, null)
+    }
+  }
 }

--- a/modules/records/versions.tf
+++ b/modules/records/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.37"
+      version = ">= 5.91"
     }
   }
 }

--- a/modules/resolver-endpoints/README.md
+++ b/modules/resolver-endpoints/README.md
@@ -8,13 +8,13 @@ This module creates Route53 Resolver Endpoints.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
 
 ## Modules
 

--- a/modules/resolver-endpoints/versions.tf
+++ b/modules/resolver-endpoints/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.91"
     }
   }
 }

--- a/modules/resolver-rule-associations/README.md
+++ b/modules/resolver-rule-associations/README.md
@@ -32,13 +32,13 @@ module "resolver_rule_associations" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.56 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
 
 ## Modules
 

--- a/modules/resolver-rule-associations/versions.tf
+++ b/modules/resolver-rule-associations/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 5.91"
     }
   }
 }

--- a/modules/zone-cross-account-vpc-association/README.md
+++ b/modules/zone-cross-account-vpc-association/README.md
@@ -41,14 +41,14 @@ module "zone_cross_account_vpc_association" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.56 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.r53_owner"></a> [aws.r53\_owner](#provider\_aws.r53\_owner) | >= 3.56 |
-| <a name="provider_aws.vpc_owner"></a> [aws.vpc\_owner](#provider\_aws.vpc\_owner) | >= 3.56 |
+| <a name="provider_aws.r53_owner"></a> [aws.r53\_owner](#provider\_aws.r53\_owner) | >= 5.91 |
+| <a name="provider_aws.vpc_owner"></a> [aws.vpc\_owner](#provider\_aws.vpc\_owner) | >= 5.91 |
 
 ## Modules
 

--- a/modules/zone-cross-account-vpc-association/versions.tf
+++ b/modules/zone-cross-account-vpc-association/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3.56"
+      version               = ">= 5.91"
       configuration_aliases = [aws.r53_owner, aws.vpc_owner]
     }
   }

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -8,13 +8,13 @@ This module creates Route53 zones.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.91 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.91 |
 
 ## Modules
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -20,4 +20,14 @@ resource "aws_route53_zone" "this" {
     lookup(each.value, "tags", {}),
     var.tags
   )
+
+  dynamic "timeouts" {
+    for_each = try([each.value.timeouts], [])
+
+    content {
+      create = try(timeouts.value.create, null)
+      update = try(timeouts.value.update, null)
+      delete = try(timeouts.value.delete, null)
+    }
+  }
 }

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.36.0"
+      version = ">= 5.91"
     }
   }
 }


### PR DESCRIPTION
## Description
Support timeouts for zones and records. 
Support CIDR routing policy for records. 
MSV AWS v5. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/issues/41741
- https://github.com/hashicorp/terraform-provider-aws/pull/29407

## Breaking Changes
Yes. MSV AWS v5. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
