### PR TITLE
feat: Allow skipping data source lookup

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_outbound_resolver_endpoints"></a> [outbound\_resolver\_endpoints](#module\_outbound\_resolver\_endpoints) | ../../modules/resolver-endpoints | n/a |
 | <a name="module_records"></a> [records](#module\_records) | ../../modules/records | n/a |
 | <a name="module_records_with_full_names"></a> [records\_with\_full\_names](#module\_records\_with\_full\_names) | ../../modules/records | n/a |
+| <a name="module_records_without_zone_lookup"></a> [records\_without\_zone\_lookup](#module\_records\_without\_zone\_lookup) | ../../modules/records | n/a |
 | <a name="module_resolver_rule_associations"></a> [resolver\_rule\_associations](#module\_resolver\_rule\_associations) | ../../modules/resolver-rule-associations | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | n/a |
 | <a name="module_terragrunt"></a> [terragrunt](#module\_terragrunt) | ../../modules/records | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -249,6 +249,17 @@ module "records" {
   depends_on = [module.zones]
 }
 
+module "records_without_zone_lookup" {
+  source = "../../modules/records"
+
+  # When skip_zone_lookup is set to true, zone_id and zone_name must be provided
+  skip_zone_lookup = true
+  zone_id          = module.zones.route53_zone_zone_id["private-vpc.terraform-aws-modules-example2.com"]
+  zone_name        = module.zones.route53_zone_name["private-vpc.terraform-aws-modules-example2.com"]
+
+  # Note that private_zone is not needed here because we are setting skip_zone_lookup to true
+}
+
 module "terragrunt" {
   source = "../../modules/records"
 

--- a/modules/records/README.md
+++ b/modules/records/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether Route53 zone is private or public | `bool` | `false` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of objects of DNS records | `any` | `[]` | no |
 | <a name="input_records_jsonencoded"></a> [records\_jsonencoded](#input\_records\_jsonencoded) | List of map of DNS records (stored as jsonencoded string, for terragrunt) | `string` | `null` | no |
+| <a name="input_skip_zone_lookup"></a> [skip\_zone\_lookup](#input\_skip\_zone\_lookup) | Whether to skip zone lookup.  If set to true, zone\_id and zone\_name must be provided | `bool` | `false` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | ID of DNS zone | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of DNS zone | `string` | `null` | no |
 

--- a/modules/records/main.tf
+++ b/modules/records/main.tf
@@ -22,7 +22,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  for_each = { for k, v in local.recordsets : k => v if var.create && (var.zone_id != null || var.zone_name != null) }
+  for_each = { for k, v in local.recordsets : k => v if var.skip_zone_lookup ? true : var.create && (var.zone_id != null || var.zone_name != null) }
 
   zone_id = local.zone_id
 

--- a/modules/records/variables.tf
+++ b/modules/records/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "skip_zone_lookup" {
+  description = "Whether to skip zone lookup.  If set to true, zone_id and zone_name must be provided"
+  type        = bool
+  default     = false
+}
+
 variable "zone_id" {
   description = "ID of DNS zone"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a `skip_zone_lookup` variable to bypass looking up the `aws_route53_zone` data source.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We would like to create DNS zones and records within the same state file.  Even when using terragrunt with two units/state files, we need the hosted zone (or at least one that we can use as a mock output) to exist or we get the following error when attempting a `run-all`:

```plaintext
  ╷
  │ Error: no matching Route 53 Hosted Zone found
  │
  │   with data.aws_route53_zone.this[0],
  │   on main.tf line 10, in data "aws_route53_zone" "this":
  │   10: data "aws_route53_zone" "this" {
  │
  ╵

  exit status 1
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

There are none.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I have used this module within our environment to create a DNS zone and records with the same plan and apply.

```terraform
module "zone" {
  source = "terraform-aws-modules/route53/aws//modules/zones"
  version = "~> 5.0"

  zones = {
    "sandbox.example.com" = {
      comment = "Sandbox domain"
      vpc     = [{ vpc_id = var.vpc_id }]
    }
  }
}

module "records" {
  source = "git@github.com:mike-carey/terraform-aws-route53//modules/records?ref=feat/skip-zone-lookup"

  skip_zone_lookup = true
  zone_id   = module.zone.route53_zone_zone_id["sandbox.example.com"]
  zone_name = module.zone.route53_zone_name["sandbox.example.com"]

  records = [
    # ... records here
  ]  
}
```

Please feel free to make any edits, change the variable name, remove or reword any comments, etc.  The ternary operators look strange, but the only way we can "short circuit" in terraform is via lazy evaluation.