### PR TITLE
fix: Remove redundant empty provider blocks

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/modules/zone-cross-account-vpc-association/versions.tf
+++ b/modules/zone-cross-account-vpc-association/versions.tf
@@ -9,11 +9,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  alias = "r53_owner"
-}
-
-provider "aws" {
-  alias = "vpc_owner"
-}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove redundant empty provider blocks that are not necessary since the `required_providers` block already defines the configuration_aliases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Suppresses the following warning during plans:

```
Warning: Redundant empty provider block

  on .terraform/modules/zone_cross_account_vpc_association/modules/zone-cross-account-vpc-association/versions.tf line 13:
  13: provider "aws" {

Earlier versions of Terraform used empty provider blocks ("proxy provider
configurations") for child modules to declare their need to be passed a
provider configuration by their callers. That approach was ambiguous and is
now deprecated.

If you control this module, you can migrate to the new declaration syntax by
removing all of the empty provider "aws" blocks and then adding or updating
an entry like the following to the required_providers block of
module.zone_cross_account_vpc_association:
    aws = {
      source = "hashicorp/aws"
      configuration_aliases = [
        aws.r53_owner,
        aws.vpc_owner,
      ]
    }
```