### PR TITLE
fix: Correct `records` output to use Route53 records resource

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -88,5 +88,5 @@ output "dnssec_kms_key_policy" {
 
 output "records" {
   description = "Records created in the Route53 zone"
-  value       = aws_route53_zone.this
+  value       = aws_route53_record.this
 }


### PR DESCRIPTION
## Description
- Correct `records` output to use Route53 records resource

## Motivation and Context
- Resolves #124

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
