### PR TITLE
fix: Catch error and fall back when `records.name` is not provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_route53_record" "this" {
   }
 
   multivalue_answer_routing_policy = each.value.multivalue_answer_routing_policy
-  name                             = coalesce(each.value.full_name, try("${each.value.name}.${local.zone_name}", null), "${each.key}.${local.zone_name}")
+  name                             = coalesce(each.value.full_name, try("${each.value.name}.${local.zone_name}", "${each.key}.${local.zone_name}"))
   records                          = each.value.records
   set_identifier                   = each.value.set_identifier
   ttl                              = each.value.ttl


### PR DESCRIPTION
## Description

Recently using this module for a full_name attribute configuration I faced this issue

```
  ╷
  │ Error: Invalid template interpolation value
  │ 
  │   on main.tf line 179, in resource "aws_route53_record" "this":
  │  179:   name                             = coalesce(each.value.full_name, "${each.value.name}.${local.zone_name}", "${each.key}.${local.zone_name}")
  │     ├────────────────
  │     │ each.value.name is null
  │ 
  │ The expression result is null. Cannot include a null value in a string
  │ template.
  ╵
```

## Motivation and Context
Add a try in the second value os the coalesce func does expect to have an attribute name

## Breaking Changes
Does not affect any previous configuration

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

