### PR TITLE
Ensure stable naming for Route53 hosted zones when name is omitted

### DIFF
--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -15,7 +15,7 @@ module "wrapper" {
   enable_dnssec                  = try(each.value.enable_dnssec, var.defaults.enable_dnssec, false)
   force_destroy                  = try(each.value.force_destroy, var.defaults.force_destroy, null)
   ignore_vpc                     = try(each.value.ignore_vpc, var.defaults.ignore_vpc, false)
-  name                           = try(each.value.name, var.defaults.name, "")
+  name                           = try(each.value.name, var.defaults.name, each.key)
   private_zone                   = try(each.value.private_zone, var.defaults.private_zone, false)
   records                        = try(each.value.records, var.defaults.records, {})
   tags                           = try(each.value.tags, var.defaults.tags, {})


### PR DESCRIPTION
This PR improves the behavior of Route53 hosted zone creation by enforcing a clear and deterministic fallback order for the name attribute.

When a hosted zone is created via for_each and name is not explicitly provided, the module now falls back to the for_each key instead of relying on implicit or generated values.

```
name = try(each.value.name, var.defaults.name, each.key)
```

This makes the hosted zone name directly reflect the configuration structure and prevents Terraform from generating unstable or opaque resource identities.

# Motivation and Context

Route53 hosted zones are long-lived, high-impact resources. Implicit naming for them is especially risky and can lead to:
	•	unexpected diffs during refactors
	•	state churn when adopting for_each
	•	hashed or auto-generated addresses in state
	•	difficult or error-prone state migrations

By intentionally using the for_each key as the final fallback for the hosted zone name, this change:
	•	aligns zone identity with the configuration itself
	•	keeps inputs clean but explicit
	•	prevents accidental renaming or replacement
	•	makes plans and state far easier to reason about

This is a small change that meaningfully improves correctness and operator confidence when managing Route53 zones.

# Breaking Changes

None.
	•	Explicit name values continue to behave exactly as before
	•	Existing defaults are preserved
	•	Only affects cases where name was previously omitted

# How Has This Been Tested?
	•	Validated against existing Route53 zone configurations
	•	Verified no diffs when upgrading from previous module versions
	•	Tested refactoring inputs to for_each without state changes
	•	Executed pre-commit run -a