### PR TITLE
feat: Allow self in alias records within same zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ resource "aws_route53_record" "this" {
     content {
       evaluate_target_health = each.value.alias.evaluate_target_health
       name                   = each.value.alias.name
-      zone_id                = each.value.alias.zone_id
+      zone_id                = each.value.alias.zone_id == "self" ? local.zone_id : each.value.alias.zone_id
     }
   }
 


### PR DESCRIPTION
## Description
Allow create alias record within same zone.

## Motivation and Context
Currently it is not possible to create ALIAS record to the same zone without explicitly specifing zone id. 
This PR solves this issue.

Example:
```
module "zone_public" {
  source = "../.."

  name    = "terraform-aws-modules-example.com"
  comment = "Public zone for terraform-aws-modules example"

  # Accelerated Recovery - provides 60-minute RTO for DNS management if us-east-1 is unavailable
  enable_accelerated_recovery = false

  # DNSSEC
  enable_dnssec = true

  records = {
    a_record = {
      name = "test"
      type = "A"
      ttl = 1800
      records = [
        "1.1.1.1",
      ]
    }
    a_alias = {
      name = "test_alias"
      type      = "A"
      ttl       = 3600
      alias = {
        name = "test.terraform-aws-modules-example.com"
        zone_id = "self"
      }
    }
}
```

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
